### PR TITLE
feat: Phase 3 - Drive Activity & Comments + manual MCP test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Binaries
 /go-google-mcp
 /gogo-mcp
+/mcp-test
 
 # Dependencies
 vendor/

--- a/cmd/mcp-test/main.go
+++ b/cmd/mcp-test/main.go
@@ -1,0 +1,179 @@
+// Manual MCP test: runs the go-google-mcp server via stdio and calls tools one by one.
+//
+// Run from repo root:
+//
+//   go build -o go-google-mcp ./cmd/go-google-mcp   # build server (faster startup)
+//   go run ./cmd/mcp-test
+//
+// Prerequisites:
+//   - Run `go-google-mcp auth login --secrets path/to/client_secrets.json` first.
+//     Otherwise the server exits with "Auth error" and the test will hang on Initialize.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// serverCommand returns (command, args) to run the MCP server. Prefers built binary in repo root.
+func serverCommand() (string, []string) {
+	if wd, err := os.Getwd(); err == nil {
+		bin := filepath.Join(wd, "go-google-mcp")
+		if info, err := os.Stat(bin); err == nil && !info.IsDir() {
+			return bin, nil
+		}
+	}
+	return "go", []string{"run", "./cmd/go-google-mcp"}
+}
+
+func main() {
+	ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
+	defer cancel()
+
+	// Prefer built binary for fast startup (run: go build -o go-google-mcp ./cmd/go-google-mcp)
+	serverCmd, serverArgs := serverCommand()
+	log.Printf("Starting MCP server: %s %s", serverCmd, strings.Join(serverArgs, " "))
+	log.Println("(If Initialize hangs, run: go-google-mcp auth login --secrets path/to/client_secrets.json)")
+
+	cli, err := client.NewStdioMCPClient(serverCmd, nil, serverArgs...)
+	if err != nil {
+		log.Fatalf("Failed to create MCP client: %v", err)
+	}
+	defer cli.Close()
+
+	// Forward server stderr so we see auth errors and logs
+	if stderr, ok := client.GetStderr(cli); ok {
+		go func() {
+			buf := make([]byte, 4096)
+			for {
+				n, err := stderr.Read(buf)
+				if n > 0 {
+					os.Stderr.Write(buf[:n])
+				}
+				if err != nil {
+					return
+				}
+			}
+		}()
+	}
+
+	// 1. Initialize
+	log.Println("--- Initialize ---")
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "mcp-test", Version: "0.1.0"}
+	result, err := cli.Initialize(ctx, initReq)
+	if err != nil {
+		log.Fatalf("Initialize failed: %v", err)
+	}
+	log.Printf("Server: %s %s\n", result.ServerInfo.Name, result.ServerInfo.Version)
+
+	// 2. List tools
+	log.Println("--- ListTools ---")
+	toolsRes, err := cli.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		log.Fatalf("ListTools failed: %v", err)
+	}
+	log.Printf("Tools (%d): ", len(toolsRes.Tools))
+	for i, t := range toolsRes.Tools {
+		if i > 0 {
+			fmt.Print(", ")
+		}
+		fmt.Print(t.Name)
+	}
+	fmt.Println()
+
+	// 3. Ping
+	log.Println("--- CallTool: ping ---")
+	pingRes, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "ping",
+			Arguments: map[string]any{"message": "hello from manual test"},
+		},
+	})
+	if err != nil {
+		log.Printf("ping failed: %v", err)
+	} else {
+		log.Printf("ping result: %s", toolResultText(pingRes))
+	}
+
+	// 4. tasks_list_tasklists
+	log.Println("--- CallTool: tasks_list_tasklists ---")
+	taskListsRes, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "tasks_list_tasklists",
+			Arguments: map[string]any{"max_results": 5},
+		},
+	})
+	if err != nil {
+		log.Printf("tasks_list_tasklists failed: %v", err)
+	} else {
+		log.Printf("tasks_list_tasklists result: %s", toolResultText(taskListsRes))
+	}
+
+	// 5. drive_search (empty query, small limit)
+	log.Println("--- CallTool: drive_search ---")
+	driveSearchRes, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "drive_search",
+			Arguments: map[string]any{"limit": 2},
+		},
+	})
+	if err != nil {
+		log.Printf("drive_search failed: %v", err)
+	} else {
+		log.Printf("drive_search result: %s", toolResultText(driveSearchRes))
+	}
+
+	// 6. drive_get_recent_activity
+	log.Println("--- CallTool: drive_get_recent_activity ---")
+	activityRes, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "drive_get_recent_activity",
+			Arguments: map[string]any{"hours": 24, "limit": 3},
+		},
+	})
+	if err != nil {
+		log.Printf("drive_get_recent_activity failed: %v", err)
+	} else {
+		log.Printf("drive_get_recent_activity result: %s", toolResultText(activityRes))
+	}
+
+	// 7. drive_find_files (needs search_term)
+	log.Println("--- CallTool: drive_find_files ---")
+	findRes, err := cli.CallTool(ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "drive_find_files",
+			Arguments: map[string]any{"search_term": "readme", "limit": 2},
+		},
+	})
+	if err != nil {
+		log.Printf("drive_find_files failed: %v", err)
+	} else {
+		log.Printf("drive_find_files result: %s", toolResultText(findRes))
+	}
+
+	log.Println("--- Manual test done ---")
+}
+
+func toolResultText(r *mcp.CallToolResult) string {
+	if r == nil {
+		return "(nil result)"
+	}
+	var parts []string
+	if r.IsError {
+		parts = append(parts, "[ERROR]")
+	}
+	for _, c := range r.Content {
+		parts = append(parts, mcp.GetTextFromContent(c))
+	}
+	return strings.TrimSpace(strings.Join(parts, " "))
+}

--- a/docs/MANUAL_MCP_TEST.md
+++ b/docs/MANUAL_MCP_TEST.md
@@ -1,0 +1,52 @@
+# Manual MCP test
+
+Run the MCP server via stdio and call tools one by one to verify behavior.
+
+## Prerequisites
+
+1. **Auth** (required for Google tools):
+   ```bash
+   go-google-mcp auth login --secrets path/to/client_secrets.json
+   ```
+   If you skip this, the server exits with "Auth error" and the test will hang on Initialize.
+
+2. **Build the server** (optional but faster startup):
+   ```bash
+   go build -o go-google-mcp ./cmd/go-google-mcp
+   ```
+
+## Run the test
+
+From the **repo root**:
+
+```bash
+go run ./cmd/mcp-test
+```
+
+The test will:
+
+1. **Initialize** – handshake with the server  
+2. **ListTools** – list all available tools  
+3. **ping** – call `ping` with message `"hello from manual test"`  
+4. **tasks_list_tasklists** – list task lists (max 5)  
+5. **drive_search** – search Drive (empty query, limit 2)  
+6. **drive_get_recent_activity** – recent activity (24h, limit 3)  
+7. **drive_find_files** – fullText search for "readme" (limit 2)  
+
+Server stderr (auth errors, logs) is forwarded to your terminal. If any tool fails (e.g. auth or API error), the test continues and prints the error.
+
+## Expected output (success)
+
+- Initialize: server name and version  
+- ListTools: list of tool names  
+- ping: `Pong: hello from manual test`  
+- tasks_list_tasklists: list of task lists or "No task lists found."  
+- drive_search: list of files or "No files found."  
+- drive_get_recent_activity: activity lines or "No recent activity found."  
+- drive_find_files: list of files or "No files found."  
+
+## Troubleshooting
+
+- **Initialize hangs** → Run `go-google-mcp auth login` and ensure token exists under `~/.go-google-mcp/`.  
+- **"Auth error" on stderr** → Same as above.  
+- **Tool returns error** → Check scope (e.g. Tasks, Drive) was granted during login; re-run login to add new scopes if needed.  

--- a/pkg/services/activity/activity.go
+++ b/pkg/services/activity/activity.go
@@ -1,0 +1,156 @@
+package activity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"google.golang.org/api/driveactivity/v2"
+	"google.golang.org/api/option"
+)
+
+// Service wraps the Drive Activity API.
+type Service struct {
+	srv *driveactivity.Service
+}
+
+// New creates a new Service.
+func New(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
+	srv, err := driveactivity.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Drive Activity client: %w", err)
+	}
+	return &Service{srv: srv}, nil
+}
+
+// ActivitySummary is a human-readable summary of a Drive activity (metadata-only, for low token usage).
+type ActivitySummary struct {
+	Timestamp string // RFC3339
+	Action    string // e.g. "Edit", "Move", "Rename", "Create", "Comment", etc.
+	Actor     string // e.g. "you" or "user@example.com"
+	Target    string // e.g. file/folder title or "items/FILE_ID"
+}
+
+// GetRecentActivity returns recent Drive activity as human-readable summaries.
+// timeRangeHours: how many hours back (default 24). itemName: optional "items/FILE_ID" to filter by file.
+func (s *Service) GetRecentActivity(timeRangeHours int, pageSize int64, itemName string) ([]ActivitySummary, error) {
+	if timeRangeHours <= 0 {
+		timeRangeHours = 24
+	}
+	if pageSize <= 0 {
+		pageSize = 20
+	}
+	if pageSize > 100 {
+		pageSize = 100
+	}
+
+	since := time.Now().Add(-time.Duration(timeRangeHours) * time.Hour)
+	filter := fmt.Sprintf("time >= \"%s\"", since.UTC().Format(time.RFC3339))
+
+	req := &driveactivity.QueryDriveActivityRequest{
+		Filter:   filter,
+		PageSize: pageSize,
+	}
+	if itemName != "" {
+		if !strings.HasPrefix(itemName, "items/") {
+			itemName = "items/" + itemName
+		}
+		req.ItemName = itemName
+	}
+
+	resp, err := s.srv.Activity.Query(req).Do()
+	if err != nil {
+		return nil, fmt.Errorf("unable to query Drive activity: %w", err)
+	}
+
+	var out []ActivitySummary
+	for _, a := range resp.Activities {
+		sum := summarizeActivity(a)
+		if sum != nil {
+			out = append(out, *sum)
+		}
+	}
+	return out, nil
+}
+
+func summarizeActivity(a *driveactivity.DriveActivity) *ActivitySummary {
+	timestamp := a.Timestamp
+	if timestamp == "" && a.TimeRange != nil {
+		timestamp = a.TimeRange.StartTime
+	}
+	action := primaryActionDetail(a)
+	actor := primaryActor(a)
+	target := primaryTarget(a)
+	if action == "" && actor == "" && target == "" {
+		return nil
+	}
+	return &ActivitySummary{
+		Timestamp: timestamp,
+		Action:    action,
+		Actor:     actor,
+		Target:    target,
+	}
+}
+
+func primaryActionDetail(a *driveactivity.DriveActivity) string {
+	if a.PrimaryActionDetail == nil {
+		return ""
+	}
+	d := a.PrimaryActionDetail
+	switch {
+	case d.Edit != nil:
+		return "Edit"
+	case d.Move != nil:
+		return "Move"
+	case d.Rename != nil:
+		return "Rename"
+	case d.Create != nil:
+		return "Create"
+	case d.Delete != nil:
+		return "Delete"
+	case d.Restore != nil:
+		return "Restore"
+	case d.PermissionChange != nil:
+		return "Permission change"
+	case d.Comment != nil:
+		return "Comment"
+	case d.Reference != nil:
+		return "Reference"
+	default:
+		return "Activity"
+	}
+}
+
+func primaryActor(a *driveactivity.DriveActivity) string {
+	if len(a.Actors) == 0 {
+		return ""
+	}
+	ac := a.Actors[0]
+	if ac.User != nil {
+		if ac.User.KnownUser != nil {
+			if ac.User.KnownUser.IsCurrentUser {
+				return "you"
+			}
+			return ac.User.KnownUser.PersonName
+		}
+	}
+	return "unknown"
+}
+
+func primaryTarget(a *driveactivity.DriveActivity) string {
+	if len(a.Targets) == 0 {
+		return ""
+	}
+	t := a.Targets[0]
+	if t.DriveItem != nil {
+		if t.DriveItem.Title != "" {
+			return t.DriveItem.Title
+		}
+		return t.DriveItem.Name
+	}
+	if t.Drive != nil {
+		return t.Drive.Title
+	}
+	return ""
+}


### PR DESCRIPTION
## Phase 3: Collaboration Context (Activity & Comments)

### Changes
- **pkg/services/activity** (new): Drive Activity API wrapper
  - `GetRecentActivity(timeRangeHours, pageSize, itemName)` — returns metadata-only summaries (Edit, Move, Rename, Create, Comment, etc.)
  - Default: last 24h; optional filter by file ID
- **drive_get_recent_activity** tool: `hours`, `limit`, optional `file_id`
- **drive_list_comments** tool: list comments on a Drive file (Doc, Sheet)
- **drive_add_comment** tool: add a plain-text comment to a Drive file
- **DriveActivityReadonlyScope** added to auth and main; auth login scopes updated

### Manual MCP test
- **cmd/mcp-test**: runs the MCP server via stdio and calls tools one by one (Initialize, ListTools, ping, tasks_list_tasklists, drive_search, drive_get_recent_activity, drive_find_files)
- **docs/MANUAL_MCP_TEST.md**: prerequisites (auth login), usage, troubleshooting
- `/mcp-test` binary added to .gitignore

### Testing
Manual test run confirmed: Initialize, ListTools, ping, tasks_list_tasklists, drive_search, drive_get_recent_activity, drive_find_files all return expected results.