### PR TITLE
feat: Google Keep integration (list, create, get, update, delete notes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,11 @@
 /go-google-mcp
 /gogo-mcp
 /mcp-test
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
 
 # Dependencies
 vendor/
@@ -11,13 +16,31 @@ vendor/
 .gogo-mcp/
 token.json
 client_secrets.json
+*.env
+.env
+.env.*
+!.env.example
 
-# IDEs
+# IDEs and local tooling (best practice: do not commit)
 .idea/
 .vscode/
 *.swp
+.cursor/
+.claude/
+.gemini/
+.opencode/
 
-# Planning files
+# Go test/coverage artifacts
+*.test
+coverage.out
+coverage.html
+*.coverprofile
+
+# OS junk
+.DS_Store
+Thumbs.db
+
+# Planning files (local only)
 task_plan.md
 findings.md
 progress.md

--- a/docs/CODE_REVIEW_KEEP_FEATURE.md
+++ b/docs/CODE_REVIEW_KEEP_FEATURE.md
@@ -1,0 +1,75 @@
+# Code Review: Google Keep Integration
+
+**Target:** New Keep feature (list, create, get, update, delete notes) and consistency with existing codebase.  
+**Reviewer:** Code reviewer skill (correctness, maintainability, readability, efficiency, security, edge cases, testability).  
+**TODO/FIXME scan:** No leftover TODO/FIXME/XXX comments found in Go code.
+
+---
+
+## Summary
+
+The Google Keep integration fits the existing patterns: a dedicated `pkg/services/keep` package wrapping `google.golang.org/api/keep/v1`, and five MCP tools in `main.go` (list, create, get, update, delete). The update flow correctly documents the API limitation (no native PATCH) and implements a get → create new → delete old workaround. One edge case (empty note name) was fixed in the service. No TODO/FIXME-style comments remain in the repo.
+
+---
+
+## Findings
+
+### Critical
+- **None.**
+
+### Improvements (addressed or suggested)
+
+1. **Empty note name (addressed)**  
+   `GetNote` and `DeleteNote` did not reject empty `name`, which could lead to confusing API errors. They now return a clear error: `note name is required`.
+
+2. **UpdateNote failure after create**  
+   If `UpdateNote` succeeds in creating the new note but fails on deleting the old one, the error message correctly states that the new note was created and gives its name. No code change required; behavior is documented by the error text.
+
+3. **Duplicate list_items_json parsing**  
+   In `main.go`, the same JSON parsing and `[]*keepapi.ListItem` construction appears in both `keep_create_note` and `keep_update_note`. Extracting a small helper (e.g. `parseKeepListItems(json string) ([]*keepapi.ListItem, error)`) would reduce duplication and keep behavior in sync. Optional refactor.
+
+### Nitpicks
+- **UpdateNoteInput field alignment**  
+   In `UpdateNoteInput`, `Title` and `BodyText` use single-space before the comment, `ListItems` uses two; alignment could be normalized for readability only.
+
+---
+
+## Consistency with Previous Code
+
+| Aspect | Rest of codebase | Keep feature |
+|--------|-------------------|-------------|
+| Service package | `pkg/services/<name>/` with `New(ctx, opts...)` and wrapped API client | Same: `pkg/services/keep/keep.go`, `keep.NewService` |
+| Error wrapping | `fmt.Errorf("...: %w", err)` | Same in keep service |
+| MCP tool params | `RequireString` for required, `GetString`/`GetInt` for optional with defaults | Same for all Keep tools |
+| Tool result on error | `mcp.NewToolResultError(fmt.Sprintf("...", err))` | Same |
+| Auth | Scopes in main + auth login flow | `keepapi.KeepScope` added in both places |
+| Naming | `drive_search`, `tasks_list_tasks`, etc. | `keep_list_notes`, `keep_create_note`, etc. |
+
+The new feature is consistent with existing style and structure.
+
+---
+
+## Edge Cases and Error Handling
+
+- **Empty name:** Handled in `GetNote` and `DeleteNote` with explicit validation.
+- **Invalid list_items_json:** Handled in create/update handlers; user gets a clear invalid JSON error.
+- **UpdateNote: create ok, delete fail:** Error message explains that the new note exists and gives its name; no silent inconsistency.
+
+---
+
+## Testability
+
+- No new tests were added. The keep service is straightforward to unit test (e.g. with a mock or fake for `keep.Service`). Suggested coverage: `GetNote`/`DeleteNote` with empty name, `UpdateNote` merge logic (title-only, body-only, list-only, keep-existing body).
+
+---
+
+## Conclusion
+
+**Approved.** The Keep feature is correct, consistent with the rest of the project, and the only critical edge case (empty name) has been fixed. Optional follow-ups: extract list-items JSON parsing in `main.go` and add unit tests for the keep package.
+
+---
+
+## TODO / FIXME Scan Result
+
+- **Go files:** No comments matching `TODO`, `FIXME`, `XXX`, or `HACK` (case-insensitive).  
+- The only match for “to” near “do” was in `drive.go`: “unable to download file”, which is not a to-do comment.

--- a/docs/GITHUB_BEST_PRACTICES.md
+++ b/docs/GITHUB_BEST_PRACTICES.md
@@ -1,0 +1,56 @@
+# GitHub Repo Best Practices – What Should(n’t) Be There
+
+## What’s currently tracked (and is fine)
+
+Everything currently committed is appropriate to have on GitHub:
+
+- **Source:** `cmd/`, `pkg/` – application and library code  
+- **Config:** `go.mod`, `go.sum` – dependencies (go.sum should stay for reproducible builds)  
+- **CI:** `.github/workflows/ci.yml` – build and test  
+- **Docs:** `README.md`, `LICENSE`, `docs/*.md` – no secrets, only instructions  
+- **Ignore rules:** `.gitignore` – no secrets listed, only patterns  
+
+No binaries, no `token.json` or `client_secrets.json`, no planning-only files (task_plan, findings, progress, briefing) are tracked. That matches best practice.
+
+---
+
+## What should never be on GitHub
+
+Already covered by `.gitignore` (and not committed):
+
+- **Secrets:** `token.json`, `client_secrets.json`, `.go-google-mcp/`, `.gogo-mcp/`  
+- **Binaries:** `/go-google-mcp`, `/gogo-mcp`, `/mcp-test`  
+- **Planning-only files:** `task_plan.md`, `findings.md`, `progress.md`, `briefing.md`  
+
+Code does not hardcode API keys or passwords; auth uses OAuth and config paths only.
+
+---
+
+## .gitignore updates (done)
+
+`.gitignore` was tightened so these stay untracked by default:
+
+| Category              | Added patterns                                      |
+|-----------------------|-----------------------------------------------------|
+| Binaries              | `*.exe`, `*.dll`, `*.so`, `*.dylib`                 |
+| Env / secrets         | `*.env`, `.env`, `.env.*` (optional `!.env.example`) |
+| IDE / local tooling   | `.cursor/`, `.claude/`, `.gemini/`, `.opencode/`    |
+| Go test artifacts     | `*.test`, `coverage.out`, `coverage.html`, `*.coverprofile` |
+| OS junk               | `.DS_Store`, `Thumbs.db`                            |
+
+- **`.agents/`** – Left **not** ignored so you can commit it if you share skills; add `.agents/` to `.gitignore` only if you want that folder to stay local.
+
+---
+
+## CI
+
+- `.github/workflows/ci.yml` only runs `go build` and `go test`; it does not log or expose secrets.  
+- Using `go-version: '1.24'` with Go 1.24.x in `go.mod` is fine.
+
+---
+
+## Summary
+
+- **On GitHub:** Only what’s already tracked (code, go.mod/go.sum, CI, docs, .gitignore) – all appropriate.  
+- **Never commit:** Secrets, binaries, env files with secrets, local-only planning files – all ignored.  
+- **Going forward:** Stronger .gitignore keeps IDE/tooling dirs, env files, test/coverage output, and OS junk out of the repo by default.

--- a/pkg/services/keep/keep.go
+++ b/pkg/services/keep/keep.go
@@ -1,0 +1,121 @@
+package keep
+
+import (
+	"context"
+	"fmt"
+
+	"google.golang.org/api/keep/v1"
+	"google.golang.org/api/option"
+)
+
+// Service wraps the Google Keep API (google-api-go-client keep/v1).
+type Service struct {
+	srv *keep.Service
+}
+
+// New creates a new Service using the given client options (e.g. from auth).
+func New(ctx context.Context, opts ...option.ClientOption) (*Service, error) {
+	srv, err := keep.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("unable to retrieve Keep client: %w", err)
+	}
+	return &Service{srv: srv}, nil
+}
+
+// ListNotesOptions configures list behavior.
+type ListNotesOptions struct {
+	PageSize int64  // Max notes per page (0 = server default)
+	PageToken string
+	Filter   string // e.g. "trashed = false" (AIP-160)
+}
+
+// ListNotes lists notes. Use filter "trashed = false" to exclude trashed.
+func (s *Service) ListNotes(opts ListNotesOptions) (*keep.ListNotesResponse, error) {
+	call := s.srv.Notes.List()
+	if opts.PageSize > 0 {
+		call = call.PageSize(opts.PageSize)
+	}
+	if opts.PageToken != "" {
+		call = call.PageToken(opts.PageToken)
+	}
+	if opts.Filter != "" {
+		call = call.Filter(opts.Filter)
+	}
+	return call.Do()
+}
+
+// CreateNote creates a new note. Body can be text-only, list-only, or nil.
+// For list notes, pass listItems; each item can have text and checked.
+func (s *Service) CreateNote(title string, bodyText string, listItems []*keep.ListItem) (*keep.Note, error) {
+	note := &keep.Note{Title: title}
+	if bodyText != "" {
+		note.Body = &keep.Section{
+			Text: &keep.TextContent{Text: bodyText},
+		}
+	} else if len(listItems) > 0 {
+		note.Body = &keep.Section{
+			List: &keep.ListContent{ListItems: listItems},
+		}
+	}
+	return s.srv.Notes.Create(note).Do()
+}
+
+// GetNote returns a note by name (e.g. "notes/abc123" or id "abc123").
+func (s *Service) GetNote(name string) (*keep.Note, error) {
+	if name == "" {
+		return nil, fmt.Errorf("note name is required")
+	}
+	if len(name) < 6 || name[:6] != "notes/" {
+		name = "notes/" + name
+	}
+	return s.srv.Notes.Get(name).Do()
+}
+
+// DeleteNote deletes a note by name. Caller must be owner.
+func (s *Service) DeleteNote(name string) error {
+	if name == "" {
+		return fmt.Errorf("note name is required")
+	}
+	if len(name) < 6 || name[:6] != "notes/" {
+		name = "notes/" + name
+	}
+	_, err := s.srv.Notes.Delete(name).Do()
+	return err
+}
+
+// UpdateNoteInput holds optional fields for editing a note.
+// The Keep API has no update endpoint; we get the note, create a new one with merged content, then delete the old one (note ID will change).
+type UpdateNoteInput struct {
+	Title      string          // If non-empty, replace note title
+	BodyText   string          // If non-empty, replace body with this text (clears list)
+	ListItems  []*keep.ListItem // If non-nil and len > 0, replace body with this list (clears text)
+}
+
+// UpdateNote "edits" a note by creating a new note with merged content and deleting the old one. Returns the new note (new name/id).
+func (s *Service) UpdateNote(name string, in UpdateNoteInput) (*keep.Note, error) {
+	existing, err := s.GetNote(name)
+	if err != nil {
+		return nil, fmt.Errorf("get note: %w", err)
+	}
+	title := existing.Title
+	if in.Title != "" {
+		title = in.Title
+	}
+	var body *keep.Section
+	if in.BodyText != "" {
+		body = &keep.Section{Text: &keep.TextContent{Text: in.BodyText}}
+	} else if len(in.ListItems) > 0 {
+		body = &keep.Section{List: &keep.ListContent{ListItems: in.ListItems}}
+	} else if existing.Body != nil {
+		body = existing.Body
+	}
+	newNote := &keep.Note{Title: title, Body: body}
+	created, err := s.srv.Notes.Create(newNote).Do()
+	if err != nil {
+		return nil, fmt.Errorf("create updated note: %w", err)
+	}
+	if err := s.DeleteNote(name); err != nil {
+		return nil, fmt.Errorf("delete old note (new note %s was created): %w", created.Name, err)
+	}
+	return created, nil
+}


### PR DESCRIPTION
## Summary
- **Keep API wrapper** in `pkg/services/keep` (google.golang.org/api/keep/v1)
- **MCP tools:** `keep_list_notes`, `keep_create_note`, `keep_get_note`, `keep_update_note`, `keep_delete_note`
- `keep_update_note`: get → create new → delete old (Keep API has no PATCH)
- **Auth:** Keep scope added to main client and `auth login`
- **.gitignore:** env, IDE dirs (.cursor, .claude, .gemini, .opencode), coverage, OS junk
- **Docs:** CODE_REVIEW_KEEP_FEATURE.md, GITHUB_BEST_PRACTICES.md