### PR TITLE
feat(auth): multi-account support via optional account parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,27 @@ This tool supports both **User OAuth 2.0** (best for personal/CLI use) and **Ser
     ```
     *This securely saves your token to `~/.go-google-mcp/`.*
 
-### Option 2: Service Account
+### Option 2: Multi-Account (Multiple Google Accounts)
+
+Use a single server instance to serve multiple Google accounts. Each tool call specifies which account to use via the `account` parameter.
+
+1.  **Login each account** (one-time per account):
+    ```bash
+    go-google-mcp auth login --account personal@gmail.com --secrets client_secrets.json
+    go-google-mcp auth login --account work@company.com --secrets client_secrets.json
+    ```
+    *Tokens are stored per account under `~/.go-google-mcp/accounts/<email>/`.*
+
+2.  **List configured accounts**:
+    ```bash
+    go-google-mcp accounts list
+    ```
+
+3.  **Use in tool calls**: Pass `"account": "work@company.com"` in any tool request. With a single account configured, it auto-selects.
+
+> **Backward compatible**: Existing single-account setups continue working unchanged. Multi-account mode activates automatically when the `accounts/` directory is detected.
+
+### Option 3: Service Account
 
 1.  Download your Service Account JSON key.
 2.  Run with the `-creds` flag:

--- a/cmd/go-google-mcp/main.go
+++ b/cmd/go-google-mcp/main.go
@@ -87,8 +87,16 @@ func main() {
 	}
 
 	// Detect multi-account mode and initialize registry.
+	// -creds (Service Account) always forces legacy mode regardless of accounts/ dir.
 	var reg *registry.Registry
-	multiAccount, _ := auth.IsMultiAccount()
+	var multiAccount bool
+	if *credentialsFile == "" {
+		var err error
+		multiAccount, err = auth.IsMultiAccount()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to detect multi-account mode: %v\n", err)
+		}
+	}
 	if multiAccount {
 		fmt.Fprintf(os.Stderr, "Multi-account mode enabled. Accounts resolved at tool call time.\n")
 		reg = registry.NewMultiAccountRegistry(scopes)

--- a/cmd/go-google-mcp/main.go
+++ b/cmd/go-google-mcp/main.go
@@ -11,14 +11,9 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/matheusbuniotto/go-google-mcp/pkg/auth"
-	activitysvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/activity"
-	calendarsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/calendar"
-	docssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/docs"
-	drivesvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/drive"
+	"github.com/matheusbuniotto/go-google-mcp/pkg/registry"
 	gmailsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/gmail"
 	keepsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/keep"
-	peoplesvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/people"
-	sheetssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/sheets"
 	taskssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/tasks"
 	"google.golang.org/api/calendar/v3"
 	"google.golang.org/api/docs/v1"
@@ -31,11 +26,41 @@ import (
 	"google.golang.org/api/tasks/v1"
 )
 
+// addTool wraps s.AddTool to conditionally inject the "account" parameter in multi-account mode.
+func addTool(s *server.MCPServer, tool mcp.Tool, handler server.ToolHandlerFunc, multiAccount bool) {
+	if multiAccount {
+		if tool.InputSchema.Properties == nil {
+			tool.InputSchema.Properties = make(map[string]any)
+		}
+		tool.InputSchema.Properties["account"] = map[string]any{
+			"type":        "string",
+			"description": "Google account email (e.g. 'user@gmail.com'). Required when multiple accounts are configured.",
+		}
+	}
+	s.AddTool(tool, handler)
+}
+
+// resolveAccount extracts the account param and resolves the ServiceSet.
+func resolveAccount(reg *registry.Registry, request mcp.CallToolRequest) (*registry.ServiceSet, *mcp.CallToolResult) {
+	account := request.GetString("account", "")
+	ss, err := reg.Resolve(account)
+	if err != nil {
+		return nil, mcp.NewToolResultError(err.Error())
+	}
+	return ss, nil
+}
+
 func main() {
 	// Subcommand parsing
-	if len(os.Args) > 1 && os.Args[1] == "auth" {
-		handleAuthCommand()
-		return
+	if len(os.Args) > 1 {
+		switch os.Args[1] {
+		case "auth":
+			handleAuthCommand()
+			return
+		case "accounts":
+			handleAccountsCommand()
+			return
+		}
 	}
 
 	// Normal server mode
@@ -60,73 +85,25 @@ func main() {
 		tasks.TasksScope,
 		driveactivity.DriveActivityReadonlyScope,
 	}
-	opts, err := auth.GetClientOptions(context.Background(), *credentialsFile, scopes)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Auth error: %v\n", err)
-		os.Exit(1)
-	}
 
-	// Initialize Drive Service
-	driveService, err := drivesvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Drive service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Gmail Service
-	gmailService, err := gmailsvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Gmail service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Calendar Service
-	calendarService, err := calendarsvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Calendar service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Sheets Service
-	sheetsService, err := sheetssvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Sheets service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize People Service
-	peopleService, err := peoplesvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create People service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Docs Service
-	docsService, err := docssvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Docs service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Tasks Service
-	tasksService, err := taskssvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Tasks service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Activity Service (Drive Activity API)
-	activityService, err := activitysvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Activity service: %v\n", err)
-		os.Exit(1)
-	}
-
-	// Initialize Keep Service (Google Keep API)
-	keepService, err := keepsvc.New(context.Background(), opts...)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create Keep service: %v\n", err)
-		os.Exit(1)
+	// Detect multi-account mode and initialize registry.
+	var reg *registry.Registry
+	multiAccount, _ := auth.IsMultiAccount()
+	if multiAccount {
+		fmt.Fprintf(os.Stderr, "Multi-account mode enabled. Accounts resolved at tool call time.\n")
+		reg = registry.NewMultiAccountRegistry(scopes)
+	} else {
+		opts, err := auth.GetClientOptions(context.Background(), *credentialsFile, scopes)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Auth error: %v\n", err)
+			os.Exit(1)
+		}
+		ss, err := registry.NewServiceSet(context.Background(), opts...)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to create services: %v\n", err)
+			os.Exit(1)
+		}
+		reg = registry.NewLegacyRegistry(ss)
 	}
 
 	// Initialize MCP Server
@@ -145,7 +122,7 @@ func main() {
 	), pingHandler)
 
 	// Tool: Drive Search
-	s.AddTool(mcp.NewTool("drive_search",
+	addTool(s, mcp.NewTool("drive_search",
 		mcp.WithDescription("Search for files in Google Drive. Use raw 'query' (Drive query syntax) OR helper args. Use content_contains for fullText search; set include_snippet to get a short preview without reading the whole file."),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of files to return (default 10)")),
 		mcp.WithString("query", mcp.Description("Raw Google Drive query string (e.g. \"name contains 'foo'\")")),
@@ -154,6 +131,11 @@ func main() {
 		mcp.WithString("mime_type", mcp.Description("Filter by exact mimeType (e.g. 'application/vnd.google-apps.folder')")),
 		mcp.WithString("include_snippet", mcp.Description("If 'true', include a short content snippet per file when using content_contains (default: false)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		limit := int64(request.GetInt("limit", 10))
 		rawQuery := request.GetString("query", "")
 		nameContains := request.GetString("name_contains", "")
@@ -178,7 +160,7 @@ func main() {
 		finalQuery := strings.Join(queryParts, " and ")
 
 		if includeSnippet && finalQuery != "" {
-			results, err := driveService.SearchFilesWithSnippets(finalQuery, limit, 300)
+			results, err := ss.Drive.SearchFilesWithSnippets(finalQuery, limit, 300)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Failed to search files: %v", err)), nil
 			}
@@ -199,7 +181,7 @@ func main() {
 			return mcp.NewToolResultText(result), nil
 		}
 
-		files, err := driveService.SearchFiles(finalQuery, limit)
+		files, err := ss.Drive.SearchFiles(finalQuery, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to search files: %v", err)), nil
 		}
@@ -211,15 +193,20 @@ func main() {
 			result = "No files found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Find Files (account-wide discovery)
-	s.AddTool(mcp.NewTool("drive_find_files",
+	addTool(s, mcp.NewTool("drive_find_files",
 		mcp.WithDescription("Find files across Google Drive by content (fullText search). Optimized for account-wide discovery when you know a phrase or keyword. Use drive_read_file to read a file's full content."),
 		mcp.WithString("search_term", mcp.Required(), mcp.Description("Phrase or keyword to search for in file content")),
 		mcp.WithNumber("limit", mcp.Description("Maximum number of files to return (default 20)")),
 		mcp.WithString("include_snippet", mcp.Description("If 'true', include a short content snippet per file (default: false)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		searchTerm, err := request.RequireString("search_term")
 		if err != nil {
 			return mcp.NewToolResultError("search_term is required"), nil
@@ -228,7 +215,7 @@ func main() {
 		includeSnippet := request.GetString("include_snippet", "false") == "true"
 
 		if includeSnippet {
-			results, err := driveService.FindFilesWithSnippets(searchTerm, limit, 300)
+			results, err := ss.Drive.FindFilesWithSnippets(searchTerm, limit, 300)
 			if err != nil {
 				return mcp.NewToolResultError(fmt.Sprintf("Failed to find files: %v", err)), nil
 			}
@@ -249,7 +236,7 @@ func main() {
 			return mcp.NewToolResultText(result), nil
 		}
 
-		files, err := driveService.FindFiles(searchTerm, limit)
+		files, err := ss.Drive.FindFiles(searchTerm, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to find files: %v", err)), nil
 		}
@@ -261,35 +248,45 @@ func main() {
 			result = "No files found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Read File
-	s.AddTool(mcp.NewTool("drive_read_file",
+	addTool(s, mcp.NewTool("drive_read_file",
 		mcp.WithDescription("Read the text content of a file from Google Drive. CAUTION: Only use for text-based files."),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file to read")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
 		}
 
 		// Limit to 32KB by default to avoid blowing up context
-		content, err := driveService.ReadFileContent(fileID, 32*1024)
+		content, err := ss.Drive.ReadFileContent(fileID, 32*1024)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to read file: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(content), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Create File
-	s.AddTool(mcp.NewTool("drive_create_file",
+	addTool(s, mcp.NewTool("drive_create_file",
 		mcp.WithDescription("Create a new text file in Google Drive"),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the file")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Text content of the file")),
 		mcp.WithString("parent_id", mcp.Description("ID of the parent folder (optional)")),
 		mcp.WithString("mime_type", mcp.Description("MimeType (optional, default: text/plain)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		name, err := request.RequireString("name")
 		if err != nil {
 			return mcp.NewToolResultError("name is required"), nil
@@ -301,36 +298,41 @@ func main() {
 		parentID := request.GetString("parent_id", "")
 		mimeType := request.GetString("mime_type", "text/plain")
 
-		file, err := driveService.CreateFile(name, parentID, content, mimeType)
+		file, err := ss.Drive.CreateFile(name, parentID, content, mimeType)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create file: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created file: %s (ID: %s)", file.Name, file.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Create Folder
-	s.AddTool(mcp.NewTool("drive_create_folder",
+	addTool(s, mcp.NewTool("drive_create_folder",
 		mcp.WithDescription("Create a new folder in Google Drive"),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Name of the folder")),
 		mcp.WithString("parent_id", mcp.Description("ID of the parent folder (optional)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		name, err := request.RequireString("name")
 		if err != nil {
 			return mcp.NewToolResultError("name is required"), nil
 		}
 		parentID := request.GetString("parent_id", "")
 
-		folder, err := driveService.CreateFolder(name, parentID)
+		folder, err := ss.Drive.CreateFolder(name, parentID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create folder: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created folder: %s (ID: %s)", folder.Name, folder.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Update File
-	s.AddTool(mcp.NewTool("drive_update_file",
+	addTool(s, mcp.NewTool("drive_update_file",
 		mcp.WithDescription("Update a file's metadata or content in Google Drive"),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file to update")),
 		mcp.WithString("name", mcp.Description("New name (optional)")),
@@ -338,6 +340,11 @@ func main() {
 		mcp.WithString("add_parent_id", mcp.Description("Add this parent folder ID (optional, effectively moving/aliasing)")),
 		mcp.WithString("remove_parent_id", mcp.Description("Remove this parent folder ID (optional)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
@@ -352,38 +359,48 @@ func main() {
 			contentPtr = &content
 		}
 
-		file, err := driveService.UpdateFile(fileID, name, addParent, removeParent, contentPtr)
+		file, err := ss.Drive.UpdateFile(fileID, name, addParent, removeParent, contentPtr)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update file: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Updated file: %s (ID: %s)", file.Name, file.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Trash File
-	s.AddTool(mcp.NewTool("drive_trash_file",
+	addTool(s, mcp.NewTool("drive_trash_file",
 		mcp.WithDescription("Move a file or folder to trash (recoverable)"),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file/folder to trash")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
 		}
 
-		if err := driveService.TrashFile(fileID); err != nil {
+		if err := ss.Drive.TrashFile(fileID); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to trash file: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Trashed file: %s", fileID)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Share File
-	s.AddTool(mcp.NewTool("drive_share_file",
+	addTool(s, mcp.NewTool("drive_share_file",
 		mcp.WithDescription("Share a file/folder with a user"),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file")),
 		mcp.WithString("email", mcp.Required(), mcp.Description("Email address to share with")),
 		mcp.WithString("role", mcp.Description("Role: 'reader', 'commenter', 'writer' (default: reader)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
@@ -394,25 +411,30 @@ func main() {
 		}
 		role := request.GetString("role", "reader")
 
-		if err := driveService.AddPermission(fileID, role, "user", email); err != nil {
+		if err := ss.Drive.AddPermission(fileID, role, "user", email); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to share file: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Shared file %s with %s as %s", fileID, email, role)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Get Recent Activity
-	s.AddTool(mcp.NewTool("drive_get_recent_activity",
+	addTool(s, mcp.NewTool("drive_get_recent_activity",
 		mcp.WithDescription("Get recent Drive activity as human-readable summaries (Edit, Move, Rename, Create, Comment, etc.). Metadata-only to save tokens."),
 		mcp.WithNumber("hours", mcp.Description("How many hours back to look (default 24)")),
 		mcp.WithNumber("limit", mcp.Description("Max activities to return (default 20, max 100)")),
 		mcp.WithString("file_id", mcp.Description("Optional: filter by file ID (items/FILE_ID or just FILE_ID)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		hours := request.GetInt("hours", 24)
 		limit := int64(request.GetInt("limit", 20))
 		fileID := request.GetString("file_id", "")
 
-		summaries, err := activityService.GetRecentActivity(hours, limit, fileID)
+		summaries, err := ss.Activity.GetRecentActivity(hours, limit, fileID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get activity: %v", err)), nil
 		}
@@ -425,21 +447,26 @@ func main() {
 			result = "No recent activity found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive List Comments
-	s.AddTool(mcp.NewTool("drive_list_comments",
+	addTool(s, mcp.NewTool("drive_list_comments",
 		mcp.WithDescription("List comments on a Drive file (e.g. Google Doc, Sheet). Use file_id from drive_search or drive_find_files."),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file")),
 		mcp.WithNumber("limit", mcp.Description("Max comments to return (default 50, max 100)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
 		}
 		limit := int64(request.GetInt("limit", 50))
 
-		comments, err := driveService.ListComments(fileID, limit)
+		comments, err := ss.Drive.ListComments(fileID, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list comments: %v", err)), nil
 		}
@@ -460,14 +487,19 @@ func main() {
 			result = "No comments found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Drive Add Comment
-	s.AddTool(mcp.NewTool("drive_add_comment",
+	addTool(s, mcp.NewTool("drive_add_comment",
 		mcp.WithDescription("Add a comment to a Drive file (e.g. Google Doc, Sheet). Use file_id from drive_search or drive_find_files."),
 		mcp.WithString("file_id", mcp.Required(), mcp.Description("ID of the file")),
 		mcp.WithString("content", mcp.Required(), mcp.Description("Plain text content of the comment")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		fileID, err := request.RequireString("file_id")
 		if err != nil {
 			return mcp.NewToolResultError("file_id is required"), nil
@@ -477,23 +509,28 @@ func main() {
 			return mcp.NewToolResultError("content is required"), nil
 		}
 
-		comment, err := driveService.CreateComment(fileID, content)
+		comment, err := ss.Drive.CreateComment(fileID, content)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to add comment: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Comment added (ID: %s)", comment.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail List Threads
-	s.AddTool(mcp.NewTool("gmail_list_threads",
+	addTool(s, mcp.NewTool("gmail_list_threads",
 		mcp.WithDescription("List/Search email threads in Gmail"),
 		mcp.WithString("query", mcp.Description("Gmail search query (e.g. 'from:boss', 'is:unread')")),
 		mcp.WithNumber("limit", mcp.Description("Max threads to return (default 10)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		query := request.GetString("query", "")
 		limit := int64(request.GetInt("limit", 10))
 
-		threads, err := gmailService.ListThreads(query, limit)
+		threads, err := ss.Gmail.ListThreads(query, limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list threads: %v", err)), nil
 		}
@@ -506,19 +543,24 @@ func main() {
 			result = "No threads found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail Read Thread
-	s.AddTool(mcp.NewTool("gmail_read_thread",
+	addTool(s, mcp.NewTool("gmail_read_thread",
 		mcp.WithDescription("Read a specific email thread"),
 		mcp.WithString("thread_id", mcp.Required(), mcp.Description("ID of the thread to read")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		threadID, err := request.RequireString("thread_id")
 		if err != nil {
 			return mcp.NewToolResultError("thread_id is required"), nil
 		}
 
-		thread, err := gmailService.GetThread(threadID)
+		thread, err := ss.Gmail.GetThread(threadID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get thread: %v", err)), nil
 		}
@@ -540,15 +582,20 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail Send Email
-	s.AddTool(mcp.NewTool("gmail_send_email",
+	addTool(s, mcp.NewTool("gmail_send_email",
 		mcp.WithDescription("Send an email"),
 		mcp.WithString("to", mcp.Required(), mcp.Description("Recipient email address")),
 		mcp.WithString("subject", mcp.Required(), mcp.Description("Email subject")),
 		mcp.WithString("body", mcp.Required(), mcp.Description("Email body content")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		to, err := request.RequireString("to")
 		if err != nil {
 			return mcp.NewToolResultError("to is required"), nil
@@ -562,21 +609,26 @@ func main() {
 			return mcp.NewToolResultError("body is required"), nil
 		}
 
-		msg, err := gmailService.SendEmail(to, subject, body)
+		msg, err := ss.Gmail.SendEmail(to, subject, body)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to send email: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Email sent! ID: %s", msg.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail Create Draft
-	s.AddTool(mcp.NewTool("gmail_create_draft",
+	addTool(s, mcp.NewTool("gmail_create_draft",
 		mcp.WithDescription("Create a draft email"),
 		mcp.WithString("to", mcp.Required(), mcp.Description("Recipient email address")),
 		mcp.WithString("subject", mcp.Required(), mcp.Description("Email subject")),
 		mcp.WithString("body", mcp.Required(), mcp.Description("Email body content")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		to, err := request.RequireString("to")
 		if err != nil {
 			return mcp.NewToolResultError("to is required"), nil
@@ -590,36 +642,46 @@ func main() {
 			return mcp.NewToolResultError("body is required"), nil
 		}
 
-		draft, err := gmailService.CreateDraft(to, subject, body)
+		draft, err := ss.Gmail.CreateDraft(to, subject, body)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create draft: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Draft created! ID: %s", draft.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail Trash Thread
-	s.AddTool(mcp.NewTool("gmail_trash_thread",
+	addTool(s, mcp.NewTool("gmail_trash_thread",
 		mcp.WithDescription("Move an email thread to trash"),
 		mcp.WithString("thread_id", mcp.Required(), mcp.Description("ID of the thread to trash")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		threadID, err := request.RequireString("thread_id")
 		if err != nil {
 			return mcp.NewToolResultError("thread_id is required"), nil
 		}
 
-		if err := gmailService.TrashThread(threadID); err != nil {
+		if err := ss.Gmail.TrashThread(threadID); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to trash thread: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Thread %s moved to trash.", threadID)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Gmail List Labels
-	s.AddTool(mcp.NewTool("gmail_list_labels",
+	addTool(s, mcp.NewTool("gmail_list_labels",
 		mcp.WithDescription("List all Gmail labels"),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		labels, err := gmailService.ListLabels()
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
+		labels, err := ss.Gmail.ListLabels()
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list labels: %v", err)), nil
 		}
@@ -629,22 +691,27 @@ func main() {
 			result += fmt.Sprintf("ID: %s | Name: %s | Type: %s\n", l.Id, l.Name, l.Type)
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Calendar List Events
-	s.AddTool(mcp.NewTool("calendar_list_events",
+	addTool(s, mcp.NewTool("calendar_list_events",
 		mcp.WithDescription("List upcoming events from Google Calendar"),
 		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
 		mcp.WithNumber("max_results", mcp.Description("Max events to return (default 10)")),
 		mcp.WithString("time_min", mcp.Description("Start time (RFC3339). Default: now.")),
 		mcp.WithString("time_max", mcp.Description("End time (RFC3339). Optional.")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		calendarID := request.GetString("calendar_id", "primary")
 		maxResults := int64(request.GetInt("max_results", 10))
 		timeMin := request.GetString("time_min", "")
 		timeMax := request.GetString("time_max", "")
 
-		events, err := calendarService.ListEvents(calendarID, maxResults, timeMin, timeMax)
+		events, err := ss.Calendar.ListEvents(calendarID, maxResults, timeMin, timeMax)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list events: %v", err)), nil
 		}
@@ -661,10 +728,10 @@ func main() {
 			result = "No upcoming events found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Calendar Create Event
-	s.AddTool(mcp.NewTool("calendar_create_event",
+	addTool(s, mcp.NewTool("calendar_create_event",
 		mcp.WithDescription("Create a new event in Google Calendar"),
 		mcp.WithString("summary", mcp.Required(), mcp.Description("Event title")),
 		mcp.WithString("start_time", mcp.Required(), mcp.Description("Start time (RFC3339, e.g. '2025-01-31T10:00:00Z')")),
@@ -673,6 +740,11 @@ func main() {
 		mcp.WithString("attendees", mcp.Description("Comma-separated list of attendee emails")),
 		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		summary, err := request.RequireString("summary")
 		if err != nil {
 			return mcp.NewToolResultError("summary is required"), nil
@@ -696,57 +768,72 @@ func main() {
 			}
 		}
 
-		event, err := calendarService.CreateEvent(calendarID, summary, description, startTime, endTime, attendees)
+		event, err := ss.Calendar.CreateEvent(calendarID, summary, description, startTime, endTime, attendees)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create event: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created event: %s (ID: %s)", event.Summary, event.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Calendar Delete Event
-	s.AddTool(mcp.NewTool("calendar_delete_event",
+	addTool(s, mcp.NewTool("calendar_delete_event",
 		mcp.WithDescription("Delete an event from Google Calendar"),
 		mcp.WithString("event_id", mcp.Required(), mcp.Description("ID of the event to delete")),
 		mcp.WithString("calendar_id", mcp.Description("Calendar ID (default: 'primary')")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		eventID, err := request.RequireString("event_id")
 		if err != nil {
 			return mcp.NewToolResultError("event_id is required"), nil
 		}
 		calendarID := request.GetString("calendar_id", "primary")
 
-		if err := calendarService.DeleteEvent(calendarID, eventID); err != nil {
+		if err := ss.Calendar.DeleteEvent(calendarID, eventID); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete event: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted event: %s", eventID)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Create Spreadsheet
-	s.AddTool(mcp.NewTool("sheets_create_spreadsheet",
+	addTool(s, mcp.NewTool("sheets_create_spreadsheet",
 		mcp.WithDescription("Create a new Google Sheet"),
 		mcp.WithString("title", mcp.Required(), mcp.Description("Title of the spreadsheet")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		title, err := request.RequireString("title")
 		if err != nil {
 			return mcp.NewToolResultError("title is required"), nil
 		}
 
-		sp, err := sheetsService.CreateSpreadsheet(title)
+		sp, err := ss.Sheets.CreateSpreadsheet(title)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create spreadsheet: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created spreadsheet: %s (ID: %s)\nURL: %s", sp.Properties.Title, sp.SpreadsheetId, sp.SpreadsheetUrl)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Read Values
-	s.AddTool(mcp.NewTool("sheets_read_values",
+	addTool(s, mcp.NewTool("sheets_read_values",
 		mcp.WithDescription("Read values from a Google Sheet range"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range (e.g. 'Sheet1!A1:C10')")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
@@ -756,7 +843,7 @@ func main() {
 			return mcp.NewToolResultError("range is required"), nil
 		}
 
-		values, err := sheetsService.ReadValues(spreadsheetID, rangeName)
+		values, err := ss.Sheets.ReadValues(spreadsheetID, rangeName)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to read values: %v", err)), nil
 		}
@@ -768,15 +855,20 @@ func main() {
 		// JSON output is often best for structured data analysis by AI
 		jsonBytes, _ := json.MarshalIndent(values, "", "  ")
 		return mcp.NewToolResultText(string(jsonBytes)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Append Values
-	s.AddTool(mcp.NewTool("sheets_append_values",
+	addTool(s, mcp.NewTool("sheets_append_values",
 		mcp.WithDescription("Append values to a Google Sheet (new rows)"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range (e.g. 'Sheet1!A1')")),
 		mcp.WithString("values_json", mcp.Required(), mcp.Description("JSON array of arrays (e.g. '[[\"A\", \"B\"]]') or single array for one row")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
@@ -790,21 +882,26 @@ func main() {
 			return mcp.NewToolResultError("values_json is required"), nil
 		}
 
-		resp, err := sheetsService.AppendValues(spreadsheetID, rangeName, valuesJSON)
+		resp, err := ss.Sheets.AppendValues(spreadsheetID, rangeName, valuesJSON)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to append values: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Appended %d cells.", resp.Updates.UpdatedCells)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Update Values
-	s.AddTool(mcp.NewTool("sheets_update_values",
+	addTool(s, mcp.NewTool("sheets_update_values",
 		mcp.WithDescription("Update values in a Google Sheet range (overwrite)"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range (e.g. 'Sheet1!A1')")),
 		mcp.WithString("values_json", mcp.Required(), mcp.Description("JSON array of arrays")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
@@ -818,24 +915,29 @@ func main() {
 			return mcp.NewToolResultError("values_json is required"), nil
 		}
 
-		resp, err := sheetsService.UpdateValues(spreadsheetID, rangeName, valuesJSON)
+		resp, err := ss.Sheets.UpdateValues(spreadsheetID, rangeName, valuesJSON)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update values: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Updated %d cells.", resp.UpdatedCells)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Get Spreadsheet (metadata, sheet IDs and titles)
-	s.AddTool(mcp.NewTool("sheets_get_spreadsheet",
+	addTool(s, mcp.NewTool("sheets_get_spreadsheet",
 		mcp.WithDescription("Get spreadsheet metadata including sheet IDs and titles"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
 		}
-		sp, err := sheetsService.GetSpreadsheet(spreadsheetID)
+		sp, err := ss.Sheets.GetSpreadsheet(spreadsheetID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to get spreadsheet: %v", err)), nil
 		}
@@ -843,23 +945,28 @@ func main() {
 			SheetId int64  `json:"sheetId"`
 			Title   string `json:"title"`
 		}
-		var sheets []sheetInfo
+		var sheetsList []sheetInfo
 		for _, sh := range sp.Sheets {
 			if sh.Properties != nil {
-				sheets = append(sheets, sheetInfo{SheetId: sh.Properties.SheetId, Title: sh.Properties.Title})
+				sheetsList = append(sheetsList, sheetInfo{SheetId: sh.Properties.SheetId, Title: sh.Properties.Title})
 			}
 		}
-		out := map[string]interface{}{"spreadsheetId": sp.SpreadsheetId, "title": sp.Properties.Title, "sheets": sheets}
+		out := map[string]interface{}{"spreadsheetId": sp.SpreadsheetId, "title": sp.Properties.Title, "sheets": sheetsList}
 		jsonBytes, _ := json.MarshalIndent(out, "", "  ")
 		return mcp.NewToolResultText(string(jsonBytes)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Batch Update (add sheet, rename sheet, etc.)
-	s.AddTool(mcp.NewTool("sheets_batch_update",
+	addTool(s, mcp.NewTool("sheets_batch_update",
 		mcp.WithDescription("Apply batch update: add sheets, rename sheets. Pass requests as JSON (e.g. {\"requests\": [{\"addSheet\": {\"properties\": {\"title\": \"TabName\"}}}]})"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 		mcp.WithString("requests_json", mcp.Required(), mcp.Description("JSON object with \"requests\" array (Google Sheets BatchUpdateSpreadsheetRequest)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
@@ -875,19 +982,24 @@ func main() {
 					"Example: {\"requests\":[{\"addSheet\":{\"properties\":{\"title\":\"Sheet\"}}}]}. Error: %v",
 				err)), nil
 		}
-		resp, err := sheetsService.BatchUpdate(spreadsheetID, &req)
+		resp, err := ss.Sheets.BatchUpdate(spreadsheetID, &req)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to batch update: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Batch update applied. Replies: %d", len(resp.Replies))), nil
-	})
+	}, multiAccount)
 
 	// Tool: Sheets Clear Values
-	s.AddTool(mcp.NewTool("sheets_clear_values",
+	addTool(s, mcp.NewTool("sheets_clear_values",
 		mcp.WithDescription("Clear values in a range"),
 		mcp.WithString("spreadsheet_id", mcp.Required(), mcp.Description("ID of the spreadsheet")),
 		mcp.WithString("range", mcp.Required(), mcp.Description("A1 notation range (e.g. 'Sheet1!A7:Z100')")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		spreadsheetID, err := request.RequireString("spreadsheet_id")
 		if err != nil {
 			return mcp.NewToolResultError("spreadsheet_id is required"), nil
@@ -896,21 +1008,26 @@ func main() {
 		if err != nil {
 			return mcp.NewToolResultError("range is required"), nil
 		}
-		_, err = sheetsService.ClearValues(spreadsheetID, rangeName)
+		_, err = ss.Sheets.ClearValues(spreadsheetID, rangeName)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to clear values: %v", err)), nil
 		}
 		return mcp.NewToolResultText("Range cleared."), nil
-	})
+	}, multiAccount)
 
 	// Tool: People List Connections
-	s.AddTool(mcp.NewTool("people_list_connections",
+	addTool(s, mcp.NewTool("people_list_connections",
 		mcp.WithDescription("List contacts (connections)"),
 		mcp.WithNumber("limit", mcp.Description("Max contacts to return (default 10)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		limit := int64(request.GetInt("limit", 10))
 
-		connections, err := peopleService.ListConnections(limit)
+		connections, err := ss.People.ListConnections(limit)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list connections: %v", err)), nil
 		}
@@ -931,15 +1048,20 @@ func main() {
 			result = "No connections found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: People Create Contact
-	s.AddTool(mcp.NewTool("people_create_contact",
+	addTool(s, mcp.NewTool("people_create_contact",
 		mcp.WithDescription("Create a new contact"),
 		mcp.WithString("given_name", mcp.Required(), mcp.Description("First name")),
 		mcp.WithString("family_name", mcp.Description("Last name")),
 		mcp.WithString("email", mcp.Description("Email address")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		givenName, err := request.RequireString("given_name")
 		if err != nil {
 			return mcp.NewToolResultError("given_name is required"), nil
@@ -947,52 +1069,62 @@ func main() {
 		familyName := request.GetString("family_name", "")
 		email := request.GetString("email", "")
 
-		person, err := peopleService.CreateContact(givenName, familyName, email)
+		person, err := ss.People.CreateContact(givenName, familyName, email)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create contact: %v", err)), nil
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created contact: %s (ID: %s)", givenName, person.ResourceName)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Docs Create Document
-	s.AddTool(mcp.NewTool("docs_create_document",
+	addTool(s, mcp.NewTool("docs_create_document",
 		mcp.WithDescription("Create a new Google Doc"),
 		mcp.WithString("title", mcp.Required(), mcp.Description("Document title")),
 		mcp.WithString("initial_text", mcp.Description("Initial text content to insert")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		title, err := request.RequireString("title")
 		if err != nil {
 			return mcp.NewToolResultError("title is required"), nil
 		}
 		initialText := request.GetString("initial_text", "")
 
-		doc, err := docsService.CreateDocument(title)
+		doc, err := ss.Docs.CreateDocument(title)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create document: %v", err)), nil
 		}
 
 		if initialText != "" {
-			if err := docsService.InsertText(doc.DocumentId, initialText); err != nil {
+			if err := ss.Docs.InsertText(doc.DocumentId, initialText); err != nil {
 				// We still return success for creation, but note the error
 				return mcp.NewToolResultText(fmt.Sprintf("Created document: %s (ID: %s)\nWarning: Failed to insert initial text: %v", doc.Title, doc.DocumentId, err)), nil
 			}
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created document: %s (ID: %s)", doc.Title, doc.DocumentId)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Docs Read Document
-	s.AddTool(mcp.NewTool("docs_read_document",
+	addTool(s, mcp.NewTool("docs_read_document",
 		mcp.WithDescription("Read a Google Doc"),
 		mcp.WithString("document_id", mcp.Required(), mcp.Description("ID of the document")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		docID, err := request.RequireString("document_id")
 		if err != nil {
 			return mcp.NewToolResultError("document_id is required"), nil
 		}
 
-		doc, err := docsService.GetDocument(docID)
+		doc, err := ss.Docs.GetDocument(docID)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to read document: %v", err)), nil
 		}
@@ -1012,16 +1144,21 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Title: %s\n\n%s", doc.Title, text)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Tasks List Task Lists
-	s.AddTool(mcp.NewTool("tasks_list_tasklists",
+	addTool(s, mcp.NewTool("tasks_list_tasklists",
 		mcp.WithDescription("List the user's Google Tasks task lists. Call this first to get task_list_id for other tasks operations."),
 		mcp.WithNumber("max_results", mcp.Description("Max task lists to return (default 100)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		maxResults := int64(request.GetInt("max_results", 100))
 
-		lists, err := tasksService.ListTaskLists(maxResults)
+		lists, err := ss.Tasks.ListTaskLists(maxResults)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to list task lists: %v", err)), nil
 		}
@@ -1034,15 +1171,20 @@ func main() {
 			result = "No task lists found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Tasks List Tasks
-	s.AddTool(mcp.NewTool("tasks_list_tasks",
+	addTool(s, mcp.NewTool("tasks_list_tasks",
 		mcp.WithDescription("List tasks in a Google Tasks list. Use tasks_list_tasklists first to get task_list_id."),
 		mcp.WithString("task_list_id", mcp.Required(), mcp.Description("ID of the task list")),
 		mcp.WithString("show_completed", mcp.Description("Include completed tasks: 'true' or 'false' (default: false to reduce output)")),
 		mcp.WithNumber("max_results", mcp.Description("Max tasks to return (default 20, max 100)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		taskListID, err := request.RequireString("task_list_id")
 		if err != nil {
 			return mcp.NewToolResultError("task_list_id is required"), nil
@@ -1050,7 +1192,7 @@ func main() {
 		showCompleted := request.GetString("show_completed", "false") == "true"
 		maxResults := int64(request.GetInt("max_results", 20))
 
-		taskList, err := tasksService.ListTasks(taskListID, taskssvc.ListTasksOptions{
+		taskList, err := ss.Tasks.ListTasks(taskListID, taskssvc.ListTasksOptions{
 			ShowCompleted: showCompleted,
 			MaxResults:    maxResults,
 		})
@@ -1074,16 +1216,21 @@ func main() {
 			result = "No tasks found."
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Tasks Insert Task
-	s.AddTool(mcp.NewTool("tasks_insert_task",
+	addTool(s, mcp.NewTool("tasks_insert_task",
 		mcp.WithDescription("Create a new task in a Google Tasks list"),
 		mcp.WithString("task_list_id", mcp.Required(), mcp.Description("ID of the task list")),
 		mcp.WithString("title", mcp.Required(), mcp.Description("Task title")),
 		mcp.WithString("notes", mcp.Description("Optional notes")),
 		mcp.WithString("due", mcp.Description("Due date (RFC3339 date, e.g. 2025-02-01)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		taskListID, err := request.RequireString("task_list_id")
 		if err != nil {
 			return mcp.NewToolResultError("task_list_id is required"), nil
@@ -1095,15 +1242,15 @@ func main() {
 		notes := request.GetString("notes", "")
 		due := request.GetString("due", "")
 
-		task, err := tasksService.InsertTask(taskListID, title, notes, due)
+		task, err := ss.Tasks.InsertTask(taskListID, title, notes, due)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to insert task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Created task: %s (ID: %s)", task.Title, task.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Tasks Update Task
-	s.AddTool(mcp.NewTool("tasks_update_task",
+	addTool(s, mcp.NewTool("tasks_update_task",
 		mcp.WithDescription("Update an existing task (title, notes, due date, or status)"),
 		mcp.WithString("task_list_id", mcp.Required(), mcp.Description("ID of the task list")),
 		mcp.WithString("task_id", mcp.Required(), mcp.Description("ID of the task")),
@@ -1112,6 +1259,11 @@ func main() {
 		mcp.WithString("due", mcp.Description("New due date RFC3339 (optional)")),
 		mcp.WithString("status", mcp.Description("'needsAction' or 'completed' (optional)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		taskListID, err := request.RequireString("task_list_id")
 		if err != nil {
 			return mcp.NewToolResultError("task_list_id is required"), nil
@@ -1139,19 +1291,24 @@ func main() {
 			in.Status = &status
 		}
 
-		task, err := tasksService.UpdateTask(taskListID, taskID, in)
+		task, err := ss.Tasks.UpdateTask(taskListID, taskID, in)
 		if err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Updated task: %s (ID: %s)", task.Title, task.Id)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Tasks Delete Task
-	s.AddTool(mcp.NewTool("tasks_delete_task",
+	addTool(s, mcp.NewTool("tasks_delete_task",
 		mcp.WithDescription("Delete a task from a Google Tasks list"),
 		mcp.WithString("task_list_id", mcp.Required(), mcp.Description("ID of the task list")),
 		mcp.WithString("task_id", mcp.Required(), mcp.Description("ID of the task to delete")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		taskListID, err := request.RequireString("task_list_id")
 		if err != nil {
 			return mcp.NewToolResultError("task_list_id is required"), nil
@@ -1161,24 +1318,29 @@ func main() {
 			return mcp.NewToolResultError("task_id is required"), nil
 		}
 
-		if err := tasksService.DeleteTask(taskListID, taskID); err != nil {
+		if err := ss.Tasks.DeleteTask(taskListID, taskID); err != nil {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted task: %s", taskID)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Keep List Notes
-	s.AddTool(mcp.NewTool("keep_list_notes",
+	addTool(s, mcp.NewTool("keep_list_notes",
 		mcp.WithDescription("List Google Keep notes. Use note name from results for keep_get_note and keep_delete_note."),
 		mcp.WithNumber("page_size", mcp.Description("Max notes per page (default 20, 0 = server default)")),
 		mcp.WithString("page_token", mcp.Description("Page token from previous list response for next page")),
 		mcp.WithString("filter", mcp.Description("Filter (e.g. 'trashed = false' to exclude trashed). AIP-160 syntax.")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		pageSize := int64(request.GetInt("page_size", 20))
 		pageToken := request.GetString("page_token", "")
 		filter := request.GetString("filter", "trashed = false")
 
-		resp, err := keepService.ListNotes(keepsvc.ListNotesOptions{
+		resp, err := ss.Keep.ListNotes(keepsvc.ListNotesOptions{
 			PageSize:  pageSize,
 			PageToken: pageToken,
 			Filter:    filter,
@@ -1200,15 +1362,20 @@ func main() {
 			result += fmt.Sprintf("\nnext_page_token: %s", resp.NextPageToken)
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Keep Create Note
-	s.AddTool(mcp.NewTool("keep_create_note",
+	addTool(s, mcp.NewTool("keep_create_note",
 		mcp.WithDescription("Create a new Google Keep note. Provide title and either body_text (plain note) or list_items_json (checklist). List items: [{\"text\":\"item 1\",\"checked\":false},{\"text\":\"item 2\",\"checked\":true}]"),
 		mcp.WithString("title", mcp.Required(), mcp.Description("Note title (max 1000 chars)")),
 		mcp.WithString("body_text", mcp.Description("Plain text body for the note (max 20000 chars). Omit if using list_items_json.")),
 		mcp.WithString("list_items_json", mcp.Description("JSON array of list items: [{\"text\":\"...\",\"checked\":false}]. Omit for text-only note.")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		title, err := request.RequireString("title")
 		if err != nil {
 			return mcp.NewToolResultError("title is required"), nil
@@ -1233,7 +1400,7 @@ func main() {
 			}
 		}
 
-		note, err := keepService.CreateNote(title, bodyText, listItems)
+		note, err := ss.Keep.CreateNote(title, bodyText, listItems)
 		if err != nil {
 			if isKeepUnavailableError(err) {
 				return mcp.NewToolResultError(keepUnavailableMessage), nil
@@ -1241,19 +1408,24 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Created note: %s (name: %s)", note.Title, note.Name)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Keep Get Note
-	s.AddTool(mcp.NewTool("keep_get_note",
+	addTool(s, mcp.NewTool("keep_get_note",
 		mcp.WithDescription("Get a Google Keep note by name or id. Returns title, body text or list items, and metadata."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Note name (e.g. notes/xyz) or note id (xyz)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		name, err := request.RequireString("name")
 		if err != nil {
 			return mcp.NewToolResultError("name is required"), nil
 		}
 
-		note, err := keepService.GetNote(name)
+		note, err := ss.Keep.GetNote(name)
 		if err != nil {
 			if isKeepUnavailableError(err) {
 				return mcp.NewToolResultError(keepUnavailableMessage), nil
@@ -1282,16 +1454,21 @@ func main() {
 			}
 		}
 		return mcp.NewToolResultText(result), nil
-	})
+	}, multiAccount)
 
 	// Tool: Keep Update Note (edit)
-	s.AddTool(mcp.NewTool("keep_update_note",
+	addTool(s, mcp.NewTool("keep_update_note",
 		mcp.WithDescription("Edit a Google Keep note. API has no native update; replaces note with a new one (new id) and deletes the old. Provide name and any of: title, body_text, list_items_json to change."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Note name (e.g. notes/xyz) or note id to edit")),
 		mcp.WithString("title", mcp.Description("New title (optional)")),
 		mcp.WithString("body_text", mcp.Description("New plain text body (optional; replaces list if set)")),
 		mcp.WithString("list_items_json", mcp.Description("New list items JSON (optional; e.g. [{\"text\":\"...\",\"checked\":false}]. Replaces text body if set.)")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		name, err := request.RequireString("name")
 		if err != nil {
 			return mcp.NewToolResultError("name is required"), nil
@@ -1318,7 +1495,7 @@ func main() {
 		}
 
 		in := keepsvc.UpdateNoteInput{Title: title, BodyText: bodyText, ListItems: listItems}
-		note, err := keepService.UpdateNote(name, in)
+		note, err := ss.Keep.UpdateNote(name, in)
 		if err != nil {
 			if isKeepUnavailableError(err) {
 				return mcp.NewToolResultError(keepUnavailableMessage), nil
@@ -1326,26 +1503,31 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Updated note (new name: %s): %s", note.Name, note.Title)), nil
-	})
+	}, multiAccount)
 
 	// Tool: Keep Delete Note
-	s.AddTool(mcp.NewTool("keep_delete_note",
+	addTool(s, mcp.NewTool("keep_delete_note",
 		mcp.WithDescription("Delete a Google Keep note permanently. Caller must be owner."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Note name (e.g. notes/xyz) or note id")),
 	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		ss, errResult := resolveAccount(reg, request)
+		if errResult != nil {
+			return errResult, nil
+		}
+
 		name, err := request.RequireString("name")
 		if err != nil {
 			return mcp.NewToolResultError("name is required"), nil
 		}
 
-		if err := keepService.DeleteNote(name); err != nil {
+		if err := ss.Keep.DeleteNote(name); err != nil {
 			if isKeepUnavailableError(err) {
 				return mcp.NewToolResultError(keepUnavailableMessage), nil
 			}
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted note: %s", name)), nil
-	})
+	}, multiAccount)
 
 	// Start server (stdio)
 	if err := server.ServeStdio(s); err != nil {
@@ -1355,15 +1537,17 @@ func main() {
 }
 
 func handleAuthCommand() {
-	// We parse subcommands manually since "auth" is the command
 	if len(os.Args) < 3 {
-		fmt.Println("Usage: gogo-mcp auth login --secrets <path>")
+		fmt.Println("Usage:")
+		fmt.Println("  go-google-mcp auth login --secrets <path>                   (single account)")
+		fmt.Println("  go-google-mcp auth login --account <email> --secrets <path>  (multi-account)")
 		os.Exit(1)
 	}
 
 	if os.Args[2] == "login" {
 		loginCmd := flag.NewFlagSet("login", flag.ExitOnError)
 		secretsPath := loginCmd.String("secrets", "", "Path to client_secrets.json")
+		account := loginCmd.String("account", "", "Account name/email (enables multi-account mode)")
 		_ = loginCmd.Parse(os.Args[3:])
 
 		if *secretsPath == "" {
@@ -1372,15 +1556,12 @@ func handleAuthCommand() {
 			os.Exit(1)
 		}
 
-		// Read secrets
 		secrets, err := os.ReadFile(*secretsPath)
 		if err != nil {
 			fmt.Printf("Error reading secrets file: %v\n", err)
 			os.Exit(1)
 		}
 
-		// Perform login
-		fmt.Println("Starting OAuth 2.0 flow...")
 		scopes := []string{
 			"https://www.googleapis.com/auth/drive",
 			"https://www.googleapis.com/auth/gmail.readonly",
@@ -1392,22 +1573,54 @@ func handleAuthCommand() {
 			"https://www.googleapis.com/auth/documents",
 			tasks.TasksScope,
 			driveactivity.DriveActivityReadonlyScope,
-			// Keep scope omitted: personal accounts get invalid_scope; add keepapi.KeepScope here if using a Workspace account.
-		}
-		if err := auth.Login(context.Background(), secrets, scopes); err != nil {
-			fmt.Printf("Login failed: %v\n", err)
-			os.Exit(1)
 		}
 
-		// Save secrets for future use
-		if err := auth.SaveSecrets(*secretsPath); err != nil {
-			fmt.Printf("Warning: Failed to save secrets file for future use: %v\n", err)
+		if *account != "" {
+			fmt.Printf("Starting OAuth 2.0 flow for account %q...\n", *account)
+			if err := auth.LoginForAccount(context.Background(), *account, secrets, scopes); err != nil {
+				fmt.Printf("Login failed: %v\n", err)
+				os.Exit(1)
+			}
+			// Save shared secrets (if not already present per-account).
+			if err := auth.SaveSecrets(*secretsPath); err != nil {
+				fmt.Printf("Warning: Failed to save shared secrets: %v\n", err)
+			}
+		} else {
+			fmt.Println("Starting OAuth 2.0 flow...")
+			if err := auth.Login(context.Background(), secrets, scopes); err != nil {
+				fmt.Printf("Login failed: %v\n", err)
+				os.Exit(1)
+			}
+			if err := auth.SaveSecrets(*secretsPath); err != nil {
+				fmt.Printf("Warning: Failed to save secrets file for future use: %v\n", err)
+			}
 		}
 
-		fmt.Println("Setup complete! You can now run 'gogo-mcp' without arguments.")
+		fmt.Println("Setup complete! You can now run 'go-google-mcp' without arguments.")
 	} else {
 		fmt.Printf("Unknown auth command: %s\n", os.Args[2])
 		os.Exit(1)
+	}
+}
+
+func handleAccountsCommand() {
+	if len(os.Args) < 3 || os.Args[2] != "list" {
+		fmt.Println("Usage: go-google-mcp accounts list")
+		os.Exit(1)
+	}
+	accounts, err := auth.ListAccounts()
+	if err != nil {
+		fmt.Printf("Error: %v\n", err)
+		os.Exit(1)
+	}
+	if len(accounts) == 0 {
+		fmt.Println("No accounts configured.")
+		fmt.Println("Use: go-google-mcp auth login --account <email> --secrets <path>")
+		return
+	}
+	fmt.Printf("Configured accounts (%d):\n", len(accounts))
+	for _, a := range accounts {
+		fmt.Printf("  - %s\n", a)
 	}
 }
 

--- a/cmd/go-google-mcp/main.go
+++ b/cmd/go-google-mcp/main.go
@@ -27,14 +27,21 @@ import (
 )
 
 // addTool wraps s.AddTool to conditionally inject the "account" parameter in multi-account mode.
-func addTool(s *server.MCPServer, tool mcp.Tool, handler server.ToolHandlerFunc, multiAccount bool) {
+// When accountNames is non-empty, the known accounts are listed in the description as a hint
+// (NOT a strict enum — accounts added mid-session are also accepted).
+func addTool(s *server.MCPServer, tool mcp.Tool, handler server.ToolHandlerFunc, multiAccount bool, accountNames []string) {
 	if multiAccount {
 		if tool.InputSchema.Properties == nil {
 			tool.InputSchema.Properties = make(map[string]any)
 		}
+		desc := "Google account email to use."
+		if len(accountNames) > 0 {
+			desc = fmt.Sprintf("Known accounts: %s. %s", strings.Join(accountNames, ", "), desc)
+		}
+		desc += " Required when multiple accounts are configured."
 		tool.InputSchema.Properties["account"] = map[string]any{
 			"type":        "string",
-			"description": "Google account email (e.g. 'user@gmail.com'). Required when multiple accounts are configured.",
+			"description": desc,
 		}
 	}
 	s.AddTool(tool, handler)
@@ -97,9 +104,17 @@ func main() {
 			fmt.Fprintf(os.Stderr, "Warning: failed to detect multi-account mode: %v\n", err)
 		}
 	}
+	// accountNames holds the account emails known at startup (for Layer 2 hints).
+	// This is a snapshot; accounts added mid-session are discovered via list_accounts (Layer 3)
+	// or the self-healing error in Resolve (Layer 1).
+	var accountNames []string
+
 	if multiAccount {
 		fmt.Fprintf(os.Stderr, "Multi-account mode enabled. Accounts resolved at tool call time.\n")
 		reg = registry.NewMultiAccountRegistry(scopes)
+		if names, err := auth.ListAccounts(); err == nil {
+			accountNames = names
+		}
 	} else {
 		opts, err := auth.GetClientOptions(context.Background(), *credentialsFile, scopes)
 		if err != nil {
@@ -128,6 +143,45 @@ func main() {
 		mcp.WithDescription("Ping the server to check availability"),
 		mcp.WithString("message", mcp.Required(), mcp.Description("Message to echo back")),
 	), pingHandler)
+
+	// Tool: List Accounts (Layer 3 — runtime account discovery)
+	// Registered directly via s.AddTool (not addTool) because this tool does NOT
+	// need the account parameter itself. Only registered in multi-account mode.
+	if multiAccount {
+		s.AddTool(mcp.NewTool("list_accounts",
+			mcp.WithDescription("List all configured Google accounts. Use the email from the response as the 'account' parameter in other tools."),
+		), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			accounts, err := auth.ListAccounts()
+			if err != nil {
+				return mcp.NewToolResultError(fmt.Sprintf("Failed to list accounts: %v", err)), nil
+			}
+			if len(accounts) == 0 {
+				return mcp.NewToolResultError("No accounts configured. Run: go-google-mcp auth login --account <email> --secrets <path>"), nil
+			}
+
+			type accountInfo struct {
+				Email     string `json:"email"`
+				IsDefault bool   `json:"isDefault"`
+			}
+			result := struct {
+				Accounts []accountInfo `json:"accounts"`
+				Count    int           `json:"count"`
+				Tip      string        `json:"tip"`
+			}{
+				Count: len(accounts),
+				Tip:   "Pass the email as the 'account' parameter in any tool call.",
+			}
+			for i, a := range accounts {
+				result.Accounts = append(result.Accounts, accountInfo{
+					Email:     a,
+					IsDefault: i == 0 && len(accounts) == 1,
+				})
+			}
+
+			jsonBytes, _ := json.MarshalIndent(result, "", "  ")
+			return mcp.NewToolResultText(string(jsonBytes)), nil
+		})
+	}
 
 	// Tool: Drive Search
 	addTool(s, mcp.NewTool("drive_search",
@@ -201,7 +255,7 @@ func main() {
 			result = "No files found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Find Files (account-wide discovery)
 	addTool(s, mcp.NewTool("drive_find_files",
@@ -256,7 +310,7 @@ func main() {
 			result = "No files found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Read File
 	addTool(s, mcp.NewTool("drive_read_file",
@@ -280,7 +334,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(content), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Create File
 	addTool(s, mcp.NewTool("drive_create_file",
@@ -312,7 +366,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created file: %s (ID: %s)", file.Name, file.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Create Folder
 	addTool(s, mcp.NewTool("drive_create_folder",
@@ -337,7 +391,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created folder: %s (ID: %s)", folder.Name, folder.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Update File
 	addTool(s, mcp.NewTool("drive_update_file",
@@ -373,7 +427,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Updated file: %s (ID: %s)", file.Name, file.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Trash File
 	addTool(s, mcp.NewTool("drive_trash_file",
@@ -395,7 +449,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Trashed file: %s", fileID)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Share File
 	addTool(s, mcp.NewTool("drive_share_file",
@@ -424,7 +478,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Shared file %s with %s as %s", fileID, email, role)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Get Recent Activity
 	addTool(s, mcp.NewTool("drive_get_recent_activity",
@@ -455,7 +509,7 @@ func main() {
 			result = "No recent activity found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive List Comments
 	addTool(s, mcp.NewTool("drive_list_comments",
@@ -495,7 +549,7 @@ func main() {
 			result = "No comments found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Drive Add Comment
 	addTool(s, mcp.NewTool("drive_add_comment",
@@ -522,7 +576,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to add comment: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Comment added (ID: %s)", comment.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail List Threads
 	addTool(s, mcp.NewTool("gmail_list_threads",
@@ -551,7 +605,7 @@ func main() {
 			result = "No threads found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail Read Thread
 	addTool(s, mcp.NewTool("gmail_read_thread",
@@ -590,7 +644,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail Send Email
 	addTool(s, mcp.NewTool("gmail_send_email",
@@ -623,7 +677,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Email sent! ID: %s", msg.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail Create Draft
 	addTool(s, mcp.NewTool("gmail_create_draft",
@@ -656,7 +710,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Draft created! ID: %s", draft.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail Trash Thread
 	addTool(s, mcp.NewTool("gmail_trash_thread",
@@ -678,7 +732,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Thread %s moved to trash.", threadID)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Gmail List Labels
 	addTool(s, mcp.NewTool("gmail_list_labels",
@@ -699,7 +753,7 @@ func main() {
 			result += fmt.Sprintf("ID: %s | Name: %s | Type: %s\n", l.Id, l.Name, l.Type)
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Calendar List Events
 	addTool(s, mcp.NewTool("calendar_list_events",
@@ -736,7 +790,7 @@ func main() {
 			result = "No upcoming events found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Calendar Create Event
 	addTool(s, mcp.NewTool("calendar_create_event",
@@ -782,7 +836,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created event: %s (ID: %s)", event.Summary, event.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Calendar Delete Event
 	addTool(s, mcp.NewTool("calendar_delete_event",
@@ -806,7 +860,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted event: %s", eventID)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Create Spreadsheet
 	addTool(s, mcp.NewTool("sheets_create_spreadsheet",
@@ -829,7 +883,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created spreadsheet: %s (ID: %s)\nURL: %s", sp.Properties.Title, sp.SpreadsheetId, sp.SpreadsheetUrl)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Read Values
 	addTool(s, mcp.NewTool("sheets_read_values",
@@ -863,7 +917,7 @@ func main() {
 		// JSON output is often best for structured data analysis by AI
 		jsonBytes, _ := json.MarshalIndent(values, "", "  ")
 		return mcp.NewToolResultText(string(jsonBytes)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Append Values
 	addTool(s, mcp.NewTool("sheets_append_values",
@@ -896,7 +950,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Appended %d cells.", resp.Updates.UpdatedCells)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Update Values
 	addTool(s, mcp.NewTool("sheets_update_values",
@@ -929,7 +983,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Updated %d cells.", resp.UpdatedCells)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Get Spreadsheet (metadata, sheet IDs and titles)
 	addTool(s, mcp.NewTool("sheets_get_spreadsheet",
@@ -962,7 +1016,7 @@ func main() {
 		out := map[string]interface{}{"spreadsheetId": sp.SpreadsheetId, "title": sp.Properties.Title, "sheets": sheetsList}
 		jsonBytes, _ := json.MarshalIndent(out, "", "  ")
 		return mcp.NewToolResultText(string(jsonBytes)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Batch Update (add sheet, rename sheet, etc.)
 	addTool(s, mcp.NewTool("sheets_batch_update",
@@ -995,7 +1049,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to batch update: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Batch update applied. Replies: %d", len(resp.Replies))), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Sheets Clear Values
 	addTool(s, mcp.NewTool("sheets_clear_values",
@@ -1021,7 +1075,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to clear values: %v", err)), nil
 		}
 		return mcp.NewToolResultText("Range cleared."), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: People List Connections
 	addTool(s, mcp.NewTool("people_list_connections",
@@ -1056,7 +1110,7 @@ func main() {
 			result = "No connections found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: People Create Contact
 	addTool(s, mcp.NewTool("people_create_contact",
@@ -1083,7 +1137,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created contact: %s (ID: %s)", givenName, person.ResourceName)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Docs Create Document
 	addTool(s, mcp.NewTool("docs_create_document",
@@ -1115,7 +1169,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Created document: %s (ID: %s)", doc.Title, doc.DocumentId)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Docs Read Document
 	addTool(s, mcp.NewTool("docs_read_document",
@@ -1152,7 +1206,7 @@ func main() {
 		}
 
 		return mcp.NewToolResultText(fmt.Sprintf("Title: %s\n\n%s", doc.Title, text)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Tasks List Task Lists
 	addTool(s, mcp.NewTool("tasks_list_tasklists",
@@ -1179,7 +1233,7 @@ func main() {
 			result = "No task lists found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Tasks List Tasks
 	addTool(s, mcp.NewTool("tasks_list_tasks",
@@ -1224,7 +1278,7 @@ func main() {
 			result = "No tasks found."
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Tasks Insert Task
 	addTool(s, mcp.NewTool("tasks_insert_task",
@@ -1255,7 +1309,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to insert task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Created task: %s (ID: %s)", task.Title, task.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Tasks Update Task
 	addTool(s, mcp.NewTool("tasks_update_task",
@@ -1304,7 +1358,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Updated task: %s (ID: %s)", task.Title, task.Id)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Tasks Delete Task
 	addTool(s, mcp.NewTool("tasks_delete_task",
@@ -1330,7 +1384,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete task: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted task: %s", taskID)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Keep List Notes
 	addTool(s, mcp.NewTool("keep_list_notes",
@@ -1370,7 +1424,7 @@ func main() {
 			result += fmt.Sprintf("\nnext_page_token: %s", resp.NextPageToken)
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Keep Create Note
 	addTool(s, mcp.NewTool("keep_create_note",
@@ -1416,7 +1470,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to create note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Created note: %s (name: %s)", note.Title, note.Name)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Keep Get Note
 	addTool(s, mcp.NewTool("keep_get_note",
@@ -1462,7 +1516,7 @@ func main() {
 			}
 		}
 		return mcp.NewToolResultText(result), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Keep Update Note (edit)
 	addTool(s, mcp.NewTool("keep_update_note",
@@ -1511,7 +1565,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to update note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Updated note (new name: %s): %s", note.Name, note.Title)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Tool: Keep Delete Note
 	addTool(s, mcp.NewTool("keep_delete_note",
@@ -1535,7 +1589,7 @@ func main() {
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to delete note: %v", err)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Deleted note: %s", name)), nil
-	}, multiAccount)
+	}, multiAccount, accountNames)
 
 	// Start server (stdio)
 	if err := server.ServeStdio(s); err != nil {

--- a/pkg/auth/store.go
+++ b/pkg/auth/store.go
@@ -111,3 +111,140 @@ func LoadSecrets() ([]byte, error) {
 	path := filepath.Join(dir, SecretsFileName)
 	return os.ReadFile(path)
 }
+
+const AccountsDirName = "accounts"
+
+// IsMultiAccount returns true if the accounts/ subdirectory exists
+// and contains at least one account directory with a valid token.json.
+func IsMultiAccount() (bool, error) {
+	dir, err := GetConfigDir()
+	if err != nil {
+		return false, err
+	}
+	accountsDir := filepath.Join(dir, AccountsDirName)
+	entries, err := os.ReadDir(accountsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			tokenPath := filepath.Join(accountsDir, e.Name(), TokenFileName)
+			if _, err := os.Stat(tokenPath); err == nil {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+// ListAccounts returns the names of all configured accounts
+// (directory names under accounts/ that contain a valid token.json).
+func ListAccounts() ([]string, error) {
+	dir, err := GetConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	accountsDir := filepath.Join(dir, AccountsDirName)
+	entries, err := os.ReadDir(accountsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var accounts []string
+	for _, e := range entries {
+		if e.IsDir() {
+			tokenPath := filepath.Join(accountsDir, e.Name(), TokenFileName)
+			if _, err := os.Stat(tokenPath); err == nil {
+				accounts = append(accounts, e.Name())
+			}
+		}
+	}
+	return accounts, nil
+}
+
+// GetAccountDir returns the config directory for a specific account.
+// Creates it if it doesn't exist.
+func GetAccountDir(account string) (string, error) {
+	dir, err := GetConfigDir()
+	if err != nil {
+		return "", err
+	}
+	accountDir := filepath.Join(dir, AccountsDirName, account)
+	if err := os.MkdirAll(accountDir, 0700); err != nil {
+		return "", err
+	}
+	return accountDir, nil
+}
+
+// SaveTokenForAccount saves an OAuth2 token for a specific account.
+func SaveTokenForAccount(account string, token *oauth2.Token) error {
+	dir, err := GetAccountDir(account)
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, TokenFileName)
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	return json.NewEncoder(f).Encode(token)
+}
+
+// LoadTokenForAccount loads the OAuth2 token for a specific account.
+func LoadTokenForAccount(account string) (*oauth2.Token, error) {
+	dir, err := GetAccountDir(account)
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(dir, TokenFileName)
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	var token oauth2.Token
+	if err := json.NewDecoder(f).Decode(&token); err != nil {
+		return nil, err
+	}
+	return &token, nil
+}
+
+// LoadSecretsForAccount loads client secrets for an account.
+// Falls back to the shared (root-level) client_secrets.json if the
+// account doesn't have its own.
+func LoadSecretsForAccount(account string) ([]byte, error) {
+	// Try per-account secrets first.
+	dir, err := GetAccountDir(account)
+	if err != nil {
+		return nil, err
+	}
+	perAccount := filepath.Join(dir, SecretsFileName)
+	if data, err := os.ReadFile(perAccount); err == nil {
+		return data, nil
+	}
+	// Fall back to shared secrets.
+	return LoadSecrets()
+}
+
+// SaveSecretsForAccount copies client secrets into an account's directory.
+func SaveSecretsForAccount(account string, srcPath string) error {
+	content, err := os.ReadFile(srcPath)
+	if err != nil {
+		return err
+	}
+	dir, err := GetAccountDir(account)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, SecretsFileName), content, 0600)
+}

--- a/pkg/auth/store.go
+++ b/pkg/auth/store.go
@@ -46,7 +46,7 @@ func GetConfigDir() (string, error) {
 	return dir, nil
 }
 
-// SaveToken saves the OAuth2 token to disk.
+// SaveToken saves the OAuth2 token to disk with restricted permissions (0600).
 func SaveToken(token *oauth2.Token) error {
 	dir, err := GetConfigDir()
 	if err != nil {
@@ -54,7 +54,7 @@ func SaveToken(token *oauth2.Token) error {
 	}
 	path := filepath.Join(dir, TokenFileName)
 
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -199,14 +199,15 @@ func GetAccountDir(account string) (string, error) {
 	return accountDir, nil
 }
 
-// SaveTokenForAccount saves an OAuth2 token for a specific account.
+// SaveTokenForAccount saves an OAuth2 token for a specific account
+// with restricted permissions (0600) to prevent credential exposure.
 func SaveTokenForAccount(account string, token *oauth2.Token) error {
 	dir, err := GetAccountDir(account)
 	if err != nil {
 		return err
 	}
 	path := filepath.Join(dir, TokenFileName)
-	f, err := os.Create(path)
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return err
 	}
@@ -238,8 +239,9 @@ func LoadTokenForAccount(account string) (*oauth2.Token, error) {
 }
 
 // LoadSecretsForAccount loads client secrets for an account.
-// Falls back to the shared (root-level) client_secrets.json if the
-// account doesn't have its own.
+// Falls back to the shared (root-level) client_secrets.json only if the
+// per-account file does not exist. Other errors (permission, corruption)
+// are returned immediately to avoid silently using the wrong OAuth client.
 func LoadSecretsForAccount(account string) ([]byte, error) {
 	// Try per-account secrets first.
 	dir, err := GetAccountDir(account)
@@ -247,8 +249,12 @@ func LoadSecretsForAccount(account string) ([]byte, error) {
 		return nil, err
 	}
 	perAccount := filepath.Join(dir, SecretsFileName)
-	if data, err := os.ReadFile(perAccount); err == nil {
+	data, err := os.ReadFile(perAccount)
+	if err == nil {
 		return data, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("per-account secrets for %q unreadable: %w", account, err)
 	}
 	// Fall back to shared secrets.
 	return LoadSecrets()

--- a/pkg/auth/store_account_test.go
+++ b/pkg/auth/store_account_test.go
@@ -1,0 +1,221 @@
+package auth
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/oauth2"
+)
+
+func TestMultiAccount(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "gogo-mcp-multi-test")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(tmpDir)
+	}()
+
+	// Override BaseDir so GetConfigDir uses our temp dir.
+	origBaseDir := BaseDir
+	BaseDir = tmpDir
+	defer func() { BaseDir = origBaseDir }()
+
+	// Also clear env var to avoid interference.
+	origEnv := os.Getenv("GO_GOOGLE_MCP_CONFIG_DIR")
+	os.Unsetenv("GO_GOOGLE_MCP_CONFIG_DIR")
+	defer func() {
+		if origEnv != "" {
+			os.Setenv("GO_GOOGLE_MCP_CONFIG_DIR", origEnv)
+		}
+	}()
+
+	t.Run("IsMultiAccount_NoDir", func(t *testing.T) {
+		multi, err := IsMultiAccount()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if multi {
+			t.Error("expected false when accounts/ dir doesn't exist")
+		}
+	})
+
+	t.Run("IsMultiAccount_EmptyDir", func(t *testing.T) {
+		configDir, _ := GetConfigDir()
+		accountsDir := filepath.Join(configDir, AccountsDirName)
+		if err := os.MkdirAll(accountsDir, 0700); err != nil {
+			t.Fatalf("failed to create accounts dir: %v", err)
+		}
+
+		multi, err := IsMultiAccount()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if multi {
+			t.Error("expected false when accounts/ dir is empty")
+		}
+
+		// Clean up for subsequent tests.
+		_ = os.RemoveAll(accountsDir)
+	})
+
+	t.Run("IsMultiAccount_DirWithoutToken", func(t *testing.T) {
+		configDir, _ := GetConfigDir()
+		accountDir := filepath.Join(configDir, AccountsDirName, "user@example.com")
+		if err := os.MkdirAll(accountDir, 0700); err != nil {
+			t.Fatalf("failed to create account dir: %v", err)
+		}
+
+		multi, err := IsMultiAccount()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if multi {
+			t.Error("expected false when account dir has no token.json")
+		}
+
+		_ = os.RemoveAll(filepath.Join(configDir, AccountsDirName))
+	})
+
+	t.Run("SaveAndLoadTokenForAccount", func(t *testing.T) {
+		account := "test@gmail.com"
+		token := &oauth2.Token{
+			AccessToken: "account-test-token",
+		}
+
+		if err := SaveTokenForAccount(account, token); err != nil {
+			t.Fatalf("failed to save token: %v", err)
+		}
+
+		loaded, err := LoadTokenForAccount(account)
+		if err != nil {
+			t.Fatalf("failed to load token: %v", err)
+		}
+		if loaded.AccessToken != token.AccessToken {
+			t.Errorf("expected %s, got %s", token.AccessToken, loaded.AccessToken)
+		}
+	})
+
+	t.Run("IsMultiAccount_WithValidAccount", func(t *testing.T) {
+		// The previous test created test@gmail.com with a token.
+		multi, err := IsMultiAccount()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !multi {
+			t.Error("expected true when account with token.json exists")
+		}
+	})
+
+	t.Run("ListAccounts", func(t *testing.T) {
+		// Add a second account.
+		token2 := &oauth2.Token{AccessToken: "token2"}
+		if err := SaveTokenForAccount("work@company.com", token2); err != nil {
+			t.Fatalf("failed to save second token: %v", err)
+		}
+
+		accounts, err := ListAccounts()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(accounts) != 2 {
+			t.Fatalf("expected 2 accounts, got %d: %v", len(accounts), accounts)
+		}
+
+		// Accounts should include both.
+		found := map[string]bool{}
+		for _, a := range accounts {
+			found[a] = true
+		}
+		if !found["test@gmail.com"] || !found["work@company.com"] {
+			t.Errorf("expected test@gmail.com and work@company.com, got %v", accounts)
+		}
+	})
+
+	t.Run("ListAccounts_NoDir", func(t *testing.T) {
+		// Use a fresh temp dir with no accounts.
+		freshDir, _ := os.MkdirTemp("", "gogo-mcp-fresh")
+		defer func() { _ = os.RemoveAll(freshDir) }()
+		BaseDir = freshDir
+
+		accounts, err := ListAccounts()
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(accounts) != 0 {
+			t.Errorf("expected 0 accounts, got %d", len(accounts))
+		}
+
+		BaseDir = tmpDir // restore
+	})
+
+	t.Run("LoadSecretsForAccount_FallbackToShared", func(t *testing.T) {
+		account := "fallback@example.com"
+		_ = SaveTokenForAccount(account, &oauth2.Token{AccessToken: "x"})
+
+		// Write shared secrets to root config dir.
+		configDir, _ := GetConfigDir()
+		sharedContent := []byte(`{"shared": true}`)
+		_ = os.WriteFile(filepath.Join(configDir, SecretsFileName), sharedContent, 0600)
+
+		loaded, err := LoadSecretsForAccount(account)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(loaded) != string(sharedContent) {
+			t.Errorf("expected shared secrets, got %s", string(loaded))
+		}
+	})
+
+	t.Run("LoadSecretsForAccount_PerAccountOverride", func(t *testing.T) {
+		account := "override@example.com"
+
+		// Create per-account secrets.
+		accountDir, _ := GetAccountDir(account)
+		perAccountContent := []byte(`{"per_account": true}`)
+		_ = os.WriteFile(filepath.Join(accountDir, SecretsFileName), perAccountContent, 0600)
+
+		loaded, err := LoadSecretsForAccount(account)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(loaded) != string(perAccountContent) {
+			t.Errorf("expected per-account secrets, got %s", string(loaded))
+		}
+	})
+
+	t.Run("SaveSecretsForAccount", func(t *testing.T) {
+		account := "savesecrets@example.com"
+
+		// Create a source secrets file.
+		srcPath := filepath.Join(tmpDir, "test_secrets.json")
+		content := []byte(`{"client_id": "test-save"}`)
+		_ = os.WriteFile(srcPath, content, 0644)
+
+		if err := SaveSecretsForAccount(account, srcPath); err != nil {
+			t.Fatalf("failed to save secrets: %v", err)
+		}
+
+		// Verify it was saved.
+		accountDir, _ := GetAccountDir(account)
+		loaded, err := os.ReadFile(filepath.Join(accountDir, SecretsFileName))
+		if err != nil {
+			t.Fatalf("failed to read saved secrets: %v", err)
+		}
+		if string(loaded) != string(content) {
+			t.Errorf("expected %s, got %s", string(content), string(loaded))
+		}
+	})
+
+	t.Run("GetAccountDir_CreatesDir", func(t *testing.T) {
+		account := "newaccount@example.com"
+		dir, err := GetAccountDir(account)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			t.Error("expected account dir to be created")
+		}
+	})
+}

--- a/pkg/auth/store_account_test.go
+++ b/pkg/auth/store_account_test.go
@@ -218,4 +218,34 @@ func TestMultiAccount(t *testing.T) {
 			t.Error("expected account dir to be created")
 		}
 	})
+
+	t.Run("PathTraversal_Rejected", func(t *testing.T) {
+		malicious := []string{
+			"../../../etc/passwd",
+			"foo/../../../etc",
+			"account/../../escape",
+			"back\\slash",
+			"null\x00byte",
+		}
+		for _, m := range malicious {
+			_, err := GetAccountDir(m)
+			if err == nil {
+				t.Errorf("expected error for malicious account name %q, got nil", m)
+			}
+		}
+	})
+
+	t.Run("ValidAccountNames_Accepted", func(t *testing.T) {
+		valid := []string{
+			"user@gmail.com",
+			"work@company.co.uk",
+			"test-account_123",
+		}
+		for _, v := range valid {
+			_, err := GetAccountDir(v)
+			if err != nil {
+				t.Errorf("expected no error for valid account name %q, got: %v", v, err)
+			}
+		}
+	})
 }

--- a/pkg/auth/store_account_test.go
+++ b/pkg/auth/store_account_test.go
@@ -235,6 +235,42 @@ func TestMultiAccount(t *testing.T) {
 		}
 	})
 
+	t.Run("SaveTokenForAccount_Permissions", func(t *testing.T) {
+		account := "perms@example.com"
+		token := &oauth2.Token{AccessToken: "perms-test"}
+
+		if err := SaveTokenForAccount(account, token); err != nil {
+			t.Fatalf("failed to save token: %v", err)
+		}
+
+		dir, _ := GetAccountDir(account)
+		info, err := os.Stat(filepath.Join(dir, TokenFileName))
+		if err != nil {
+			t.Fatalf("failed to stat token file: %v", err)
+		}
+		perm := info.Mode().Perm()
+		if perm != 0600 {
+			t.Errorf("token file permissions = %o, want 0600", perm)
+		}
+	})
+
+	t.Run("LoadSecretsForAccount_UnreadableReturnsError", func(t *testing.T) {
+		account := "unreadable@example.com"
+
+		// Create per-account secrets with no read permission.
+		accountDir, _ := GetAccountDir(account)
+		secretsPath := filepath.Join(accountDir, SecretsFileName)
+		_ = os.WriteFile(secretsPath, []byte(`{"broken": true}`), 0000)
+
+		_, err := LoadSecretsForAccount(account)
+		if err == nil {
+			t.Error("expected error for unreadable per-account secrets, got nil")
+		}
+
+		// Clean up: restore permissions so os.RemoveAll works.
+		_ = os.Chmod(secretsPath, 0600)
+	})
+
 	t.Run("ValidAccountNames_Accepted", func(t *testing.T) {
 		valid := []string{
 			"user@gmail.com",

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,168 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/matheusbuniotto/go-google-mcp/pkg/auth"
+	activitysvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/activity"
+	calendarsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/calendar"
+	docssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/docs"
+	drivesvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/drive"
+	gmailsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/gmail"
+	keepsvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/keep"
+	peoplesvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/people"
+	sheetssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/sheets"
+	taskssvc "github.com/matheusbuniotto/go-google-mcp/pkg/services/tasks"
+	"google.golang.org/api/option"
+)
+
+// ServiceSet holds all Google service instances for one account.
+type ServiceSet struct {
+	Drive    *drivesvc.DriveService
+	Gmail    *gmailsvc.GmailService
+	Calendar *calendarsvc.CalendarService
+	Sheets   *sheetssvc.SheetsService
+	People   *peoplesvc.PeopleService
+	Docs     *docssvc.DocsService
+	Tasks    *taskssvc.Service
+	Activity *activitysvc.Service
+	Keep     *keepsvc.Service
+}
+
+// NewServiceSet creates all 9 Google services with the given auth options.
+func NewServiceSet(ctx context.Context, opts ...option.ClientOption) (*ServiceSet, error) {
+	driveSvc, err := drivesvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("drive: %w", err)
+	}
+	gmailSvc, err := gmailsvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("gmail: %w", err)
+	}
+	calendarSvc, err := calendarsvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("calendar: %w", err)
+	}
+	sheetsSvc, err := sheetssvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("sheets: %w", err)
+	}
+	peopleSvc, err := peoplesvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("people: %w", err)
+	}
+	docsSvc, err := docssvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("docs: %w", err)
+	}
+	tasksSvc, err := taskssvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("tasks: %w", err)
+	}
+	activitySvc, err := activitysvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("activity: %w", err)
+	}
+	keepSvc, err := keepsvc.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("keep: %w", err)
+	}
+	return &ServiceSet{
+		Drive:    driveSvc,
+		Gmail:    gmailSvc,
+		Calendar: calendarSvc,
+		Sheets:   sheetsSvc,
+		People:   peopleSvc,
+		Docs:     docsSvc,
+		Tasks:    tasksSvc,
+		Activity: activitySvc,
+		Keep:     keepSvc,
+	}, nil
+}
+
+// Registry manages multiple account ServiceSets with lazy initialization.
+type Registry struct {
+	mu       sync.Mutex
+	accounts map[string]*ServiceSet
+	scopes   []string
+
+	// legacy is the pre-existing single-account ServiceSet (backward compat).
+	legacy *ServiceSet
+
+	// multiAccount indicates whether accounts/ directory was detected.
+	multiAccount bool
+}
+
+// NewLegacyRegistry creates a registry wrapping a single pre-initialized ServiceSet.
+// Used when no accounts/ directory exists (backward compatible mode).
+func NewLegacyRegistry(ss *ServiceSet) *Registry {
+	return &Registry{
+		legacy:       ss,
+		multiAccount: false,
+	}
+}
+
+// NewMultiAccountRegistry creates a registry for multi-account mode.
+// ServiceSets are created lazily on first use per account.
+func NewMultiAccountRegistry(scopes []string) *Registry {
+	return &Registry{
+		accounts:     make(map[string]*ServiceSet),
+		scopes:       scopes,
+		multiAccount: true,
+	}
+}
+
+// IsMultiAccount returns whether the registry is in multi-account mode.
+func (r *Registry) IsMultiAccount() bool {
+	return r.multiAccount
+}
+
+// Resolve returns the ServiceSet for a tool call.
+//
+// Resolution rules:
+//   - Legacy mode: always returns the legacy ServiceSet (account param ignored).
+//   - Multi-account, account provided: returns that account's ServiceSet (lazy init).
+//   - Multi-account, account empty, 1 account: auto-selects the single account.
+//   - Multi-account, account empty, N accounts: returns error with account list.
+func (r *Registry) Resolve(account string) (*ServiceSet, error) {
+	if !r.multiAccount {
+		return r.legacy, nil
+	}
+
+	if account == "" {
+		accounts, err := auth.ListAccounts()
+		if err != nil {
+			return nil, fmt.Errorf("failed to list accounts: %w", err)
+		}
+		switch len(accounts) {
+		case 0:
+			return nil, fmt.Errorf("no accounts configured; run: go-google-mcp auth login --account <email> --secrets <path>")
+		case 1:
+			account = accounts[0]
+		default:
+			return nil, fmt.Errorf("multiple accounts available, please specify 'account' parameter; available: %v", accounts)
+		}
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if ss, ok := r.accounts[account]; ok {
+		return ss, nil
+	}
+
+	// Lazy init: create service set for this account.
+	ctx := context.Background()
+	opts, err := auth.GetClientOptionsForAccount(ctx, account, r.scopes)
+	if err != nil {
+		return nil, fmt.Errorf("auth for account %q: %w", account, err)
+	}
+	ss, err := NewServiceSet(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("services for account %q: %w", account, err)
+	}
+	r.accounts[account] = ss
+	return ss, nil
+}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -49,6 +49,15 @@ func TestNewMultiAccountRegistry(t *testing.T) {
 	auth.BaseDir = tmpDir
 	defer func() { auth.BaseDir = origBaseDir }()
 
+	// Clear env var that takes precedence over BaseDir in GetConfigDir().
+	origEnv := os.Getenv("GO_GOOGLE_MCP_CONFIG_DIR")
+	os.Unsetenv("GO_GOOGLE_MCP_CONFIG_DIR")
+	defer func() {
+		if origEnv != "" {
+			os.Setenv("GO_GOOGLE_MCP_CONFIG_DIR", origEnv)
+		}
+	}()
+
 	reg := NewMultiAccountRegistry([]string{"scope1"})
 
 	if !reg.IsMultiAccount() {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"testing"
+)
+
+func TestNewLegacyRegistry(t *testing.T) {
+	// In legacy mode, Resolve always returns the same ServiceSet.
+	ss := &ServiceSet{} // empty but non-nil
+	reg := NewLegacyRegistry(ss)
+
+	if reg.IsMultiAccount() {
+		t.Error("legacy registry should not be multi-account")
+	}
+
+	t.Run("EmptyAccount", func(t *testing.T) {
+		got, err := reg.Resolve("")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ss {
+			t.Error("expected same ServiceSet pointer")
+		}
+	})
+
+	t.Run("AnyAccount", func(t *testing.T) {
+		got, err := reg.Resolve("ignored@example.com")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != ss {
+			t.Error("expected same ServiceSet pointer regardless of account param")
+		}
+	})
+}
+
+func TestNewMultiAccountRegistry(t *testing.T) {
+	reg := NewMultiAccountRegistry([]string{"scope1"})
+
+	if !reg.IsMultiAccount() {
+		t.Error("multi-account registry should be multi-account")
+	}
+
+	// Without any accounts configured, Resolve("") should fail.
+	// Note: this test depends on no accounts/ dir existing in the
+	// test environment. The auth.ListAccounts call will return empty
+	// since BaseDir defaults to the home dir, but we can't guarantee
+	// this in all environments. This is more of a smoke test.
+	t.Run("EmptyAccountNoAccounts", func(t *testing.T) {
+		_, err := reg.Resolve("")
+		if err == nil {
+			t.Error("expected error when no accounts configured and account param empty")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

Adds the ability to serve **multiple Google accounts from a single `go-google-mcp` instance**. Each tool call accepts an optional `account` parameter to specify which account to use, eliminating the need to run N separate instances (and N × 42 duplicated tools) for N accounts.

- **Backward compatible**: existing single-account setups work unchanged. Multi-account mode auto-activates when `~/.go-google-mcp/accounts/` contains configured accounts.
- **Lazy initialization**: service instances are created on-demand per account (not at startup), keeping memory/startup lightweight.
- **Thread-safe**: concurrent tool calls across different accounts are handled via `sync.Mutex` in the registry.

### How it works

```bash
# Login multiple accounts (one-time each)
go-google-mcp auth login --account personal@gmail.com --secrets client_secrets.json
go-google-mcp auth login --account work@company.com --secrets client_secrets.json

# List configured accounts
go-google-mcp accounts list

# Tool calls specify account
{"tool": "calendar_list_events", "arguments": {"account": "work@company.com"}}
```

### Directory structure

```
~/.go-google-mcp/
├── client_secrets.json        # shared OAuth secrets (fallback)
├── token.json                 # legacy single-account token
└── accounts/                  # presence triggers multi-account mode
    ├── personal@gmail.com/
    │   └── token.json
    └── work@company.com/
        └── token.json
```

### Changes

| File | Change |
|------|--------|
| `pkg/auth/store.go` | Account-aware token/secrets storage (7 new functions) |
| `pkg/auth/auth.go` | `GetClientOptionsForAccount()` |
| `pkg/auth/login.go` | `LoginForAccount()` with explicit mux |
| `pkg/registry/registry.go` | **New**: `ServiceSet` + `Registry` with lazy init |
| `cmd/go-google-mcp/main.go` | Wire registry, `addTool` wrapper, `resolveAccount` helper, 41 handler updates, `accounts list` CLI |
| `README.md` | Multi-account usage section |

### Motivation

This builds on PR #13 (`GO_GOOGLE_MCP_CONFIG_DIR`) which enabled multi-instance deployments. This PR replaces that pattern with a single-instance approach: 1 process, 42 tools, N accounts — instead of N processes × 42 tools.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — no issues
- [x] `go test -v -race ./...` — 17 tests pass (12 new + 5 existing)
- [x] Manual: legacy mode (no `accounts/` dir) works unchanged
- [x] Manual: multi-account login + tool calls with different accounts
- [x] Manual: auto-select when only 1 account configured
- [x] Manual: error message when N accounts, no `account` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)